### PR TITLE
Add support for request body and HTTP method

### DIFF
--- a/tests/simple/src/lib.rs
+++ b/tests/simple/src/lib.rs
@@ -3,9 +3,16 @@ use wasi_experimental_http;
 
 #[no_mangle]
 pub extern "C" fn _start() {
-    let url = "https://api.brigade.sh/healthz".to_string();
-    let req = http::request::Builder::new().uri(&url).header("abc", "def");
-    let req = req.body(()).unwrap();
+    let url = "https://postman-echo.com/post".to_string();
+    let req = http::request::Builder::new()
+        .method(http::Method::POST)
+        .uri(&url)
+        .header("Content-Type", "text/plain");
+    let b = b"Testing with a request body";
+    let req = req.body(Some(b.to_vec())).unwrap();
+
+    // let url = "https://api.brigade.sh/healthz".to_string();
+    // let req = http::request::Builder::new().uri(&url).body(None).unwrap();
 
     let res = wasi_experimental_http::request(req).expect("cannot make request");
     let str = std::str::from_utf8(&res.body()).unwrap().to_string();


### PR DESCRIPTION
This PR adds support for a `Vec<u8>` request body and HTTP method.