### PR TITLE
Return an error code from runtime and write detailed error into pointer

### DIFF
--- a/crates/wasi-experimental-http-wasmtime/src/lib.rs
+++ b/crates/wasi-experimental-http-wasmtime/src/lib.rs
@@ -1,8 +1,8 @@
-use std::str::FromStr;
-
 use anyhow::Error;
 use futures::executor::block_on;
-use reqwest::{Client, Method};
+use http::HeaderMap;
+use reqwest::{Client, Method, Response};
+use std::str::FromStr;
 use wasi_experimental_http;
 use wasmtime::*;
 
@@ -22,31 +22,55 @@ pub fn link_http(linker: &mut Linker) -> Result<(), Error> {
               req_body_len_ptr: u32,
               headers_ptr: u32,
               headers_len_ptr: u32,
+              body_res_ptr: u32,
               body_written_ptr: u32,
               headers_written_ptr: u32,
               headers_res_ptr: u32,
-              status_code_ptr: u32|
+              status_code_ptr: u32,
+              err_ptr: u32,
+              err_len_ptr: u32|
               -> u32 {
             let memory = match caller.get_export(MEMORY) {
                 Some(Extern::Memory(mem)) => mem,
-                _ => panic!("cannot find memory"),
+                _ => {
+                    return err(
+                        "cannot find memory".to_string(),
+                        None,
+                        None,
+                        err_ptr,
+                        err_len_ptr,
+                        1,
+                    )
+                }
             };
             let alloc = match caller.get_export(ALLOC_FN) {
                 Some(Extern::Func(func)) => func,
-                _ => panic!(),
+                _ => {
+                    return err(
+                        "cannot find alloc function".to_string(),
+                        None,
+                        None,
+                        err_ptr,
+                        err_len_ptr,
+                        1,
+                    )
+                }
             };
 
-            let url = unsafe { string_from_memory(&memory, url_ptr, url_len_ptr).unwrap() };
-            println!("wasi_experimental_http::req: URL: {}", url);
-
-            let headers =
-                unsafe { string_from_memory(&memory, headers_ptr, headers_len_ptr).unwrap() };
-            let headers = wasi_experimental_http::string_to_header_map(headers).unwrap();
-
-            let method =
-                unsafe { string_from_memory(&memory, method_ptr, method_len_ptr).unwrap() };
-
-            let req_body = unsafe { vec_from_memory(&memory, req_body_ptr, req_body_len_ptr) };
+            let (url, headers, method, req_body) = unsafe {
+                http_parts_from_memory(
+                    &memory,
+                    url_ptr,
+                    url_len_ptr,
+                    method_ptr,
+                    method_len_ptr,
+                    req_body_ptr,
+                    req_body_len_ptr,
+                    headers_ptr,
+                    headers_len_ptr,
+                )
+                .unwrap()
+            };
 
             // TODO
             // We probably need separate methods for blocking and non-blocking
@@ -54,41 +78,140 @@ pub fn link_http(linker: &mut Linker) -> Result<(), Error> {
             // let res = reqwest::blocking::get(&url).unwrap().text().unwrap();
 
             let client = Client::builder().build().unwrap();
-            let res = block_on(
+            let res = match block_on(
                 client
-                    .request(Method::from_str(&method).unwrap(), &url)
+                    .request(method, &url)
                     .headers(headers)
                     .body(req_body)
                     .send(),
-            )
-            .unwrap();
-            let hs = wasi_experimental_http::header_map_to_string(res.headers()).unwrap();
-            let status = res.status().as_u16();
-            let res = block_on(res.bytes()).unwrap();
-            let headers_res = write(
-                &hs.as_bytes().to_vec(),
-                headers_written_ptr,
-                memory.clone(),
-                alloc.clone(),
-            )
-            .unwrap();
+            ) {
+                Ok(r) => r,
+                Err(e) => {
+                    return err(
+                        e.to_string(),
+                        Some(&memory),
+                        Some(&alloc),
+                        err_ptr,
+                        err_len_ptr,
+                        2,
+                    )
+                }
+            };
 
             unsafe {
-                // write the headers response pointer
-                let tmp_ptr =
-                    memory.clone().data_ptr().offset(headers_res_ptr as isize) as *mut u32;
-                *tmp_ptr = headers_res as u32;
-
-                // write the status code pointer
-                let status_tmp_ptr =
-                    memory.clone().data_ptr().offset(status_code_ptr as isize) as *mut u32;
-                *status_tmp_ptr = status as u32;
+                match write_http_response_to_memory(
+                    res,
+                    memory.clone(),
+                    alloc.clone(),
+                    headers_written_ptr,
+                    headers_res_ptr,
+                    body_res_ptr,
+                    status_code_ptr,
+                    body_written_ptr,
+                ) {
+                    Ok(_) => {}
+                    Err(e) => {
+                        return err(
+                            e.to_string(),
+                            Some(&memory.clone()),
+                            Some(&alloc.clone()),
+                            err_ptr,
+                            err_len_ptr,
+                            3,
+                        )
+                    }
+                };
             }
-            write(&res.to_vec(), body_written_ptr, memory, alloc).unwrap() as u32
+            0
         },
     )?;
 
     Ok(())
+}
+
+unsafe fn http_parts_from_memory(
+    memory: &Memory,
+    url_ptr: u32,
+    url_len_ptr: u32,
+    method_ptr: u32,
+    method_len_ptr: u32,
+    req_body_ptr: u32,
+    req_body_len_ptr: u32,
+    headers_ptr: u32,
+    headers_len_ptr: u32,
+) -> Result<(String, HeaderMap, Method, Vec<u8>), Error> {
+    let url = string_from_memory(&memory, url_ptr, url_len_ptr)?;
+    let headers = string_from_memory(&memory, headers_ptr, headers_len_ptr)?;
+    let headers = wasi_experimental_http::string_to_header_map(headers)?;
+    let method = string_from_memory(&memory, method_ptr, method_len_ptr)?;
+    let method = Method::from_str(&method)?;
+    let req_body = vec_from_memory(&memory, req_body_ptr, req_body_len_ptr);
+
+    Ok((url, headers, method, req_body))
+}
+
+unsafe fn write_http_response_to_memory(
+    res: Response,
+    memory: Memory,
+    alloc: Func,
+    headers_written_ptr: u32,
+    headers_res_ptr: u32,
+    body_res_ptr: u32,
+    status_code_ptr: u32,
+    body_written_ptr: u32,
+) -> Result<(), Error> {
+    let hs = wasi_experimental_http::header_map_to_string(res.headers())?;
+    let status = res.status().as_u16();
+    let res = block_on(res.bytes())?;
+    write(
+        &hs.as_bytes().to_vec(),
+        headers_res_ptr,
+        headers_written_ptr,
+        &memory,
+        &alloc,
+    )?;
+
+    // write the status code pointer
+    let status_tmp_ptr = memory.data_ptr().offset(status_code_ptr as isize) as *mut u32;
+    *status_tmp_ptr = status as u32;
+
+    write(
+        &res.to_vec(),
+        body_res_ptr,
+        body_written_ptr,
+        &memory,
+        &alloc,
+    )?;
+
+    Ok(())
+}
+
+fn err(
+    msg: String,
+    memory: Option<&Memory>,
+    alloc: Option<&Func>,
+    err_ptr: u32,
+    err_len_ptr: u32,
+    err_code: u32,
+) -> u32 {
+    let memory = match memory {
+        Some(m) => m,
+        None => return err_code,
+    };
+    let alloc = match alloc {
+        Some(a) => a,
+        None => return err_code,
+    };
+    match write(
+        &msg.as_bytes().to_vec(),
+        err_ptr,
+        err_len_ptr,
+        memory,
+        alloc,
+    ) {
+        Ok(_) => return err_code,
+        Err(_) => return err_code,
+    }
 }
 
 /// Read a byte array from the instance's `memory`  of length `len_ptr`
@@ -109,7 +232,7 @@ unsafe fn data_from_memory(memory: &Memory, data_ptr: u32, len_ptr: u32) -> (Opt
 
 unsafe fn vec_from_memory(memory: &Memory, data_ptr: u32, len_ptr: u32) -> Vec<u8> {
     let (data, _) = data_from_memory(&memory, data_ptr, len_ptr);
-    data.unwrap().to_vec()
+    data.unwrap_or_default().to_vec()
 }
 
 /// Read a string from the instance's `memory`  of length `len_ptr`
@@ -128,8 +251,6 @@ unsafe fn string_from_memory(
         None => return Err(anyhow::Error::msg("pointer/length out of bounds")),
     };
 
-    // println!("wasi_experimental_http::string_from_memory:: data: {}", str);
-
     Ok(String::from(str))
 }
 
@@ -137,10 +258,11 @@ unsafe fn string_from_memory(
 /// and return the offset relative to the module's memory.
 fn write(
     bytes: &Vec<u8>,
+    ptr: u32,
     bytes_written_ptr: u32,
-    memory: Memory,
-    alloc: Func,
-) -> Result<isize, Error> {
+    memory: &Memory,
+    alloc: &Func,
+) -> Result<(), Error> {
     let alloc_result = alloc.call(&vec![Val::from(bytes.len() as i32)])?;
     let guest_ptr_offset = match alloc_result
         .get(0)
@@ -161,7 +283,10 @@ fn write(
             "wasi_experimental_http::write_guest_memory:: written {} bytes",
             *written_ptr
         );
+
+        let res_ptr = memory.data_ptr().offset(ptr as isize) as *mut u32;
+        *res_ptr = guest_ptr_offset as u32;
     }
 
-    Ok(guest_ptr_offset)
+    Ok(())
 }

--- a/tests/simple/src/lib.rs
+++ b/tests/simple/src/lib.rs
@@ -7,12 +7,10 @@ pub extern "C" fn _start() {
     let req = http::request::Builder::new()
         .method(http::Method::POST)
         .uri(&url)
-        .header("Content-Type", "text/plain");
-    let b = b"Testing with a request body";
+        .header("Content-Type", "text/plain")
+        .header("abc", "def");
+    let b = b"Testing with a request body. Does this actually work?";
     let req = req.body(Some(b.to_vec())).unwrap();
-
-    // let url = "https://api.brigade.sh/healthz".to_string();
-    // let req = http::request::Builder::new().uri(&url).body(None).unwrap();
 
     let res = wasi_experimental_http::request(req).expect("cannot make request");
     let str = std::str::from_utf8(&res.body()).unwrap().to_string();


### PR DESCRIPTION
This PR updates the FFI function to return an error code, and in case of an error, write the detailed error message into a pair of guest-supplied pointer and length.

closes #7 