### PR TITLE
Make request and response bodies Bytes

### DIFF
--- a/crates/wasi-experimental-http-wasmtime/Cargo.toml
+++ b/crates/wasi-experimental-http-wasmtime/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+bytes = "1"
 futures = "0.3"
 http = "0.2"
 reqwest = { version = "0.11", default-features = true, features = ["json", "blocking"] }

--- a/crates/wasi-experimental-http/Cargo.toml
+++ b/crates/wasi-experimental-http/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["Radu Matei <radu.matei@microsoft.com>"]
 edition = "2018"
 
 [dependencies]
-http = "0.2"
 anyhow = "1.0"
+bytes = "1"
+http = "0.2"
 serde_json = "1.0"
 serde = { version = "1.0.100", features = ["derive"] }

--- a/crates/wasi-experimental-http/src/lib.rs
+++ b/crates/wasi-experimental-http/src/lib.rs
@@ -1,10 +1,11 @@
 use anyhow::Error;
+use bytes::Bytes;
 use http::{self, header::HeaderName, HeaderMap, HeaderValue, Request, Response, StatusCode};
 use std::{collections::HashMap, str::FromStr};
 
 /// Create an HTTP request and get an HTTP response.
 /// Currently, both the request and response bodies have to be `Vec<u8>`.
-pub fn request(req: Request<Option<Vec<u8>>>) -> Result<Response<Vec<u8>>, Error> {
+pub fn request(req: Request<Option<Bytes>>) -> Result<Response<Bytes>, Error> {
     let url = req.uri().to_string();
     let headers = header_map_to_string(req.headers())?;
     let (body, headers, status_code) =
@@ -15,7 +16,7 @@ pub fn request(req: Request<Option<Vec<u8>>>) -> Result<Response<Vec<u8>>, Error
         std::str::from_utf8(&headers)?.to_string(),
     )?;
 
-    Ok(res.body(body)?)
+    Ok(res.body(Bytes::from(body))?)
 }
 
 // TODO
@@ -57,10 +58,10 @@ unsafe fn raw_request(
     url: &String,
     method: String,
     headers: &String,
-    body: &Option<Vec<u8>>,
+    body: &Option<Bytes>,
 ) -> Result<(Vec<u8>, Vec<u8>, u16), Error> {
     let body = match body {
-        Some(b) => b.clone(),
+        Some(b) => b.to_vec(),
         None => Vec::new(),
     };
 

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ crate to create an HTTP request from a WebAssembly module, make a host call to
 the runtime using the request, then get a response back:
 
 ```rust
+use bytes::Bytes;
 use http;
 use wasi_experimental_http;
 
@@ -21,8 +22,8 @@ pub extern "C" fn _start() {
         .uri(&url)
         .header("Content-Type", "text/plain")
         .header("abc", "def");
-    let b = b"Testing with a request body. Does this actually work?";
-    let req = req.body(Some(b.to_vec())).unwrap();
+    let b = Bytes::from("Testing with a request body. Does this actually work?");
+    let req = req.body(Some(b)).unwrap();
 
     let res = wasi_experimental_http::request(req).expect("cannot make request");
     let str = std::str::from_utf8(&res.body()).unwrap().to_string();
@@ -81,7 +82,7 @@ Note that the Wasmtime version currently supported is
 
 ### Known limitations
 
-- request and response bodies are byte arrays only (Rust `Vec<u8>`).
+- request and response bodies are [`Bytes`](https://docs.rs/bytes/1.0.1/bytes/).
 - handling headers is currently very inefficient.
 - there are no WITX definitions, which means we have to manually keep the host
   call and guest implementation in sync. Adding WITX definitions could also

--- a/tests/simple/Cargo.toml
+++ b/tests/simple/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
+bytes = "1"
 http = "0.2"
 wasi-experimental-http = { path = "../../crates/wasi-experimental-http" }

--- a/tests/simple/src/lib.rs
+++ b/tests/simple/src/lib.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use http;
 use wasi_experimental_http;
 
@@ -19,8 +20,8 @@ pub extern "C" fn post() {
         .uri(&url)
         .header("Content-Type", "text/plain")
         .header("abc", "def");
-    let b = b"Testing with a request body. Does this actually work?";
-    let req = req.body(Some(b.to_vec())).unwrap();
+    let b = Bytes::from("Testing with a request body. Does this actually work?");
+    let req = req.body(Some(b)).unwrap();
 
     let res = wasi_experimental_http::request(req).expect("cannot make post request");
     let str = std::str::from_utf8(&res.body()).unwrap().to_string();


### PR DESCRIPTION
This PR makes the request and response bodies that the user interacts with `Bytes` rather than `Vec<u8>`.

Note that the host calls will still pass byte arrays, and we can explore changing that as well.