### PR TITLE
Change the req() prototype to directly accept constant lengths

### DIFF
--- a/crates/as/index.ts
+++ b/crates/as/index.ts
@@ -115,48 +115,44 @@ export class RequestBuilder {
 // @ts-ignore: decorator
 @external("wasi_experimental_http", "req")
 @unsafe declare function req(
-        url_ptr: usize,
-        url_len_ptr: usize,
-        method_ptr: usize,
-        method_len_ptr: usize,
-        req_body_ptr: usize,
-        req_body_len_ptr: usize,
-        heders_ptr: usize,
-        headers_len_ptr: usize,
-        body_res_ptr: usize,
-        body_written_ptr: usize,
-        headers_written_ptr: usize,
-        headers_res_ptr: usize,
-        status_code_ptr: usize,
-        err_ptr: usize,
-        err_len_ptr: usize
-    ): u32;
+    url_ptr: usize,
+    url_len_ptr: usize,
+    method_ptr: usize,
+    method_len_ptr: usize,
+    req_body_ptr: usize,
+    req_body_len_ptr: usize,
+    heders_ptr: usize,
+    headers_len_ptr: usize,
+    body_res_ptr: usize,
+    body_written_ptr: usize,
+    headers_written_ptr: usize,
+    headers_res_ptr: usize,
+    status_code_ptr: usize,
+    err_ptr: usize,
+    err_written_ptr: usize
+): u32;
 
 function raw_request(
-        url: string,
-        method: string,
-        headers: string,
-        body: ArrayBuffer
-    ): Response {
+    url: string,
+    method: string,
+    headers: string,
+    body: ArrayBuffer
+): Response {
 
     let url_buf = String.UTF8.encode(url);
-    let url_len_ptr = memory.data(8);
-    store<usize>(url_len_ptr, url_buf.byteLength);
     let url_ptr = changetype<usize>(url_buf);
+    let url_len = url_buf.byteLength;
 
     let method_buf = String.UTF8.encode(method);
-    let method_len_ptr = memory.data(8);
-    store<usize>(method_len_ptr, method_buf.byteLength);
     let method_ptr = changetype<usize>(method_buf);
+    let method_len = method_buf.byteLength;
 
     let headers_buf = String.UTF8.encode(headers);
-    let headers_len_ptr = memory.data(8);
-    store<usize>(headers_len_ptr, headers_buf.byteLength);
     let headers_ptr = changetype<usize>(headers_buf);
+    let headers_len = headers_buf.byteLength;
 
     let req_body_ptr = changetype<usize>(body);
-    let req_body_len_ptr = memory.data(8);
-    store<usize>(req_body_len_ptr, body.byteLength);
+    let req_body_len = body.byteLength;
 
     let body_res_ptr = memory.data(8);
     let body_written_ptr = memory.data(8);
@@ -164,24 +160,24 @@ function raw_request(
     let headers_written_ptr = memory.data(8);
     let status_code_ptr = memory.data(8);
     let err_ptr = memory.data(8);
-    let err_len_ptr = memory.data(8);
+    let err_written_ptr = memory.data(8);
 
     let err = req(
         url_ptr,
-        url_len_ptr,
+        url_len,
         method_ptr,
-        method_len_ptr,
+        method_len,
         req_body_ptr,
-        req_body_len_ptr,
+        req_body_len,
         headers_ptr,
-        headers_len_ptr,
+        headers_len,
         body_res_ptr,
         body_written_ptr,
-        headers_written_ptr,
         headers_res_ptr,
+        headers_written_ptr,
         status_code_ptr,
         err_ptr,
-        err_len_ptr
+        err_written_ptr
     );
 
     if (err != 0) {
@@ -195,7 +191,7 @@ function raw_request(
         }
 
         // An error code was written. Read it, then abort.
-        let err_len = load<usize>(err_len_ptr) as u32;
+        let err_len = load<usize>(err_written_ptr) as u32;
         let err_buf = new ArrayBuffer(err_len);
         memory.copy(changetype<usize>(err_buf), err_ptr, err_len);
         wasi.Console.log("Runtime error: " + String.UTF8.decode(err_buf));
@@ -233,7 +229,7 @@ function headersToString(headers: Map<string, string>): string {
 }
 
 /** The standard HTTP methods. */
-export enum Method{
+export enum Method {
     GET,
     HEAD,
     POST,
@@ -247,7 +243,7 @@ export enum Method{
 
 /** Return the string representation of the HTTP method. */
 function methodEnumToString(m: Method): string {
-    switch(m) {
+    switch (m) {
         case Method.GET:
             return "GET";
         case Method.HEAD:

--- a/tests/as/package-lock.json
+++ b/tests/as/package-lock.json
@@ -1,25 +1,69 @@
 {
+  "name": "as",
+  "lockfileVersion": 2,
   "requires": true,
-  "lockfileVersion": 1,
+  "packages": {
+    "": {
+      "dependencies": {
+        "as-wasi": "0.4.4",
+        "assemblyscript": "^0.18.12"
+      }
+    },
+    "node_modules/as-wasi": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/as-wasi/-/as-wasi-0.4.4.tgz",
+      "integrity": "sha512-CNeZ3AjKSjrFXRNDRzX1VzxsWz3Fwksn4g0J7tZv5RKz4agKhVlcl0QeMIOOkJms7DujCBCpbelGxNDtvlFKmw=="
+    },
+    "node_modules/assemblyscript": {
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.18.15.tgz",
+      "integrity": "sha512-s1N1qwdBhen2SLQApYCtRIPWm1Am3oAbW58GCEKbeN6ZbQRh7nq0pv4RDqKw6CgK7dySn/F2S1D6p0scyRbQRw==",
+      "dependencies": {
+        "binaryen": "100.0.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "asc": "bin/asc",
+        "asinit": "bin/asinit"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/assemblyscript"
+      }
+    },
+    "node_modules/binaryen": {
+      "version": "100.0.0",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-100.0.0.tgz",
+      "integrity": "sha512-nxOt8d8/VXAuSVEtAWUdKrqpqCy365QqD223EzzB1GzS5himiZAfM/R5lXx+M/5q8TB8cYp3tYxv5rTjNTJveQ==",
+      "bin": {
+        "wasm-opt": "bin/wasm-opt"
+      }
+    },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    }
+  },
   "dependencies": {
     "as-wasi": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/as-wasi/-/as-wasi-0.2.0.tgz",
-      "integrity": "sha512-dQ9b0YXZx8B7t0BhGNKRbugZkyQY6dca3rOFQcoN/grlOYnPUygtYCdOKU2iLLtbCan+dgt9Ww1zgDxeRs9U/g=="
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/as-wasi/-/as-wasi-0.4.4.tgz",
+      "integrity": "sha512-CNeZ3AjKSjrFXRNDRzX1VzxsWz3Fwksn4g0J7tZv5RKz4agKhVlcl0QeMIOOkJms7DujCBCpbelGxNDtvlFKmw=="
     },
     "assemblyscript": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.18.12.tgz",
-      "integrity": "sha512-a0zJlb4xgEtxdadrrIP9MuLmQuRE6ZVzXPi2RZoVG6zgz+nLYLt1mkiP/TbJRY+4wvf1peTCZok+vyRAxFjppQ==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.18.15.tgz",
+      "integrity": "sha512-s1N1qwdBhen2SLQApYCtRIPWm1Am3oAbW58GCEKbeN6ZbQRh7nq0pv4RDqKw6CgK7dySn/F2S1D6p0scyRbQRw==",
       "requires": {
-        "binaryen": "98.0.0-nightly.20210106",
+        "binaryen": "100.0.0",
         "long": "^4.0.0"
       }
     },
     "binaryen": {
-      "version": "98.0.0-nightly.20210106",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-98.0.0-nightly.20210106.tgz",
-      "integrity": "sha512-iunAgesqT9PXVYCc72FA4h0sCCKLifruT6NuUH63xqlFJGpChhZLgOtyIb/fIgTibN5Pd692cxfBViyCWFsJ9Q=="
+      "version": "100.0.0",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-100.0.0.tgz",
+      "integrity": "sha512-nxOt8d8/VXAuSVEtAWUdKrqpqCy365QqD223EzzB1GzS5himiZAfM/R5lXx+M/5q8TB8cYp3tYxv5rTjNTJveQ=="
     },
     "long": {
       "version": "4.0.0",

--- a/tests/as/package.json
+++ b/tests/as/package.json
@@ -3,7 +3,7 @@
     "asbuild": "asc index.ts -b build/optimized.wasm --use abort=wasi_abort --debug"
   },
   "dependencies": {
-    "as-wasi": "0.2.0",
+    "as-wasi": "0.4.4",
     "assemblyscript": "^0.18.12"
   }
 }


### PR DESCRIPTION
Also:
- Make the `ptr` and `len` order consistent (it was flipped for response headers)
- Make the naming consistent, too (`err_written_ptr`)
- Use more accurate raw pointer types
- Update `as-wasi`