### PR TITLE
Don't require JSON for header serialization

### DIFF
--- a/crates/as/index.ts
+++ b/crates/as/index.ts
@@ -214,17 +214,12 @@ function raw_request(
 
 /** Transform the header map into a string. */
 function headersToString(headers: Map<string, string>): string {
-    let res: string = "{";
+    let res = "";
     let keys = headers.keys() as Array<string>;
     let values = headers.values() as Array<string>;
     for (let index = 0; index < keys.length; ++index) {
-        res += '"' + keys[index] + '"' + ":" + '"' + values[index] + '"';
-        if (index != keys.length - 1) {
-            res += ",";
-        }
+        res += '"' + keys[index] + '"' + ":" + '"' + values[index] + '"\n';
     }
-    res += "}";
-
     return res;
 }
 

--- a/crates/as/tsconfig.json
+++ b/crates/as/tsconfig.json
@@ -1,6 +1,6 @@
 {
-    "extends": "./node_modules/assemblyscript/std/assembly.json",
-    "include": [
-      "./**/*.ts"
-    ]
-  }
+  "extends": "./node_modules/assemblyscript/std/assembly.json",
+  "include": [
+    "./**/*.ts"
+  ]
+}

--- a/crates/wasi-experimental-http-wasmtime/src/lib.rs
+++ b/crates/wasi-experimental-http-wasmtime/src/lib.rs
@@ -243,7 +243,7 @@ unsafe fn http_parts_from_memory(
 ) -> Result<(String, HeaderMap, Method, Vec<u8>), Error> {
     let url = string_from_memory(&memory, url_ptr, url_len)?;
     let headers = string_from_memory(&memory, headers_ptr, headers_len)?;
-    let headers = wasi_experimental_http::string_to_header_map(headers)?;
+    let headers = wasi_experimental_http::string_to_header_map(&headers)?;
     let method = string_from_memory(&memory, method_ptr, method_len)?;
     let method = Method::from_str(&method)?;
     let req_body = vec_from_memory(&memory, req_body_ptr, req_body_len);

--- a/crates/wasi-experimental-http/Cargo.toml
+++ b/crates/wasi-experimental-http/Cargo.toml
@@ -12,6 +12,4 @@ readme = "readme.md"
 anyhow = "1.0"
 bytes = "1"
 http = "0.2"
-serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
 tracing = { version = "0.1", features = ["log"] }

--- a/crates/wasi-experimental-http/src/lib.rs
+++ b/crates/wasi-experimental-http/src/lib.rs
@@ -1,7 +1,7 @@
 use anyhow::Error;
 use bytes::Bytes;
 use http::{self, header::HeaderName, HeaderMap, HeaderValue, Request, Response, StatusCode};
-use std::{collections::HashMap, str::FromStr};
+use std::str::FromStr;
 
 /// Create an HTTP request and get an HTTP response.
 /// Currently, both the request and response bodies have to be `Vec<u8>`.
@@ -47,10 +47,12 @@ pub fn header_map_to_string(hm: &HeaderMap) -> Result<String, Error> {
 pub fn string_to_header_map(s: &str) -> Result<HeaderMap, Error> {
     let mut headers = HeaderMap::new();
     for entry in s.lines() {
-        let (k, v) = entry.split_once(':').ok_or(anyhow::format_err!(
+        let mut parts = entry.splitn(2, ':');
+        let k = parts.next().ok_or(anyhow::format_err!(
             "Invalid serialized header: [{}]",
             entry
         ))?;
+        let v = parts.next().unwrap();
         headers.insert(HeaderName::from_str(k)?, HeaderValue::from_str(v)?);
     }
     Ok(headers)


### PR DESCRIPTION
Since RFC7230 prohibites delimiters in header names, and control characters in values, headers can safely be encoded as

```text
<header>:<value>\n
<header>:<value>\n
...
```

This is printable, simple and fast to serialize/deserialize, and matches how headers are sent in HTTP 1.x

Fixes #35