### PR TITLE
Fix header parsing in AssemblyScript and return a header map rather than a string

### DIFF
--- a/crates/as/index.ts
+++ b/crates/as/index.ts
@@ -23,7 +23,7 @@ export class Response {
      * use by a consumer. This should be represented as a
      * `Map<string, string>`.
      */
-    public headers: string;
+    public headers: Map<string, string>;
     /** The response body as a byte array.
      *
      * It should be decoded by the consumer accordingly.
@@ -32,7 +32,7 @@ export class Response {
      */
     public body: ArrayBuffer;
 
-    constructor(status: u16, headers: string, body: ArrayBuffer) {
+    constructor(status: u16, headers: Map<string, string>, body: ArrayBuffer) {
         this.status = status;
         this.headers = headers;
         this.body = body;
@@ -209,7 +209,7 @@ function raw_request(
     memory.copy(changetype<usize>(headers_res_buf), load<usize>(headers_res_ptr), headers_length);
     let headers_res = String.UTF8.decode(headers_res_buf);
 
-    return new Response(status, headers_res, body_res);
+    return new Response(status, stringToHeaderMap(headers_res), body_res);
 }
 
 /** Transform the header map into a string. */
@@ -220,6 +220,19 @@ function headersToString(headers: Map<string, string>): string {
     for (let index = 0; index < keys.length; ++index) {
         res += keys[index] + ":" + values[index] + '\n';
     }
+    return res;
+}
+
+/** Transform the string representation of the headers into a map. */
+function stringToHeaderMap(headersStr: string): Map<string, string> {
+    let res = new Map<string, string>();
+    let parts = headersStr.split("\n");
+    // the result of the split contains an empty part as well
+    for(let index = 0; index < parts.length - 1; index++) {
+        let p = parts[index].split(":");
+        res.set(p[0], p[1]);
+    }
+
     return res;
 }
 

--- a/crates/as/index.ts
+++ b/crates/as/index.ts
@@ -186,7 +186,7 @@ function raw_request(
 
         // Error code 1 means no error message was written.
         if (err == 1) {
-            wasi.Console.log("Runtime error: cannot find exorted alloc function or memory");
+            wasi.Console.log("Runtime error: cannot find exported alloc function or memory");
             abort();
         }
 
@@ -218,7 +218,7 @@ function headersToString(headers: Map<string, string>): string {
     let keys = headers.keys() as Array<string>;
     let values = headers.values() as Array<string>;
     for (let index = 0; index < keys.length; ++index) {
-        res += '"' + keys[index] + '"' + ":" + '"' + values[index] + '"\n';
+        res += keys[index] + ":" + values[index] + '\n';
     }
     return res;
 }

--- a/crates/as/index.ts
+++ b/crates/as/index.ts
@@ -14,15 +14,7 @@ export function request(req: Request): Response {
 export class Response {
     /** The HTTP response status code. */
     public status: StatusCode;
-    /** The HTTP response headers.
-     *
-     * TODO
-     *
-     * For now, the response headers are represented
-     * as a string, which makes it difficult to actually
-     * use by a consumer. This should be represented as a
-     * `Map<string, string>`.
-     */
+    /** The HTTP response headers. */
     public headers: Map<string, string>;
     /** The response body as a byte array.
      *

--- a/tests/as/index.ts
+++ b/tests/as/index.ts
@@ -12,7 +12,7 @@ export function post(): void {
     .body(body)
     .send();
 
-  checkStatus(res.status);
+  check(res, 200, 7);
 }
 
 export function get(): void {
@@ -20,15 +20,35 @@ export function get(): void {
     .method(Method.GET)
     .send();
 
-  checkStatus(res.status);
+  check(res, 200, 6);
   if (String.UTF8.decode(res.body) != '"OK"') {
-    abort();
     abort();
   }
 }
 
-function checkStatus(status: number): void {
-  if (status != 200) {
+function check(
+  res: Response,
+  expectedStatus: u32,
+  expectedHeadersLen: u32
+): void {
+  if (res.status != expectedStatus) {
+    wasi.Console.write(
+      "expected status " +
+        expectedStatus.toString() +
+        " got " +
+        res.status.toString()
+    );
+    abort();
+  }
+
+  let len = (res.headers.keys() as Array<string>).length;
+  if (len != expectedHeadersLen) {
+    wasi.Console.write(
+      "expected " +
+        expectedHeadersLen.toString() +
+        " headers, got " +
+        len.toString()
+    );
     abort();
   }
 }

--- a/tests/as/index.ts
+++ b/tests/as/index.ts
@@ -7,27 +7,28 @@ export function post(): void {
   let body = String.UTF8.encode("testing the body");
   let res = new RequestBuilder("https://postman-echo.com/post")
     .header("Content-Type", "text/plain")
+    .header("abc", "def")
     .method(Method.POST)
     .body(body)
     .send();
 
-  let result = String.UTF8.decode(res.body);
-  // print(res);
+  checkStatus(res.status);
 }
 
 export function get(): void {
   let res = new RequestBuilder("https://api.brigade.sh/healthz")
     .method(Method.GET)
     .send();
-  // print(res);
+
+  checkStatus(res.status);
   if (String.UTF8.decode(res.body) != '"OK"') {
+    abort();
     abort();
   }
 }
 
-function print(res: Response): void {
-  wasi.Console.log(res.status.toString());
-  wasi.Console.log(res.headers);
-  let result = String.UTF8.decode(res.body);
-  wasi.Console.log(result);
+function checkStatus(status: number): void {
+  if (status != 200) {
+    abort();
+  }
 }

--- a/tests/as/package-lock.json
+++ b/tests/as/package-lock.json
@@ -1,50 +1,6 @@
 {
-  "name": "as",
-  "lockfileVersion": 2,
   "requires": true,
-  "packages": {
-    "": {
-      "dependencies": {
-        "as-wasi": "0.4.4",
-        "assemblyscript": "^0.18.12"
-      }
-    },
-    "node_modules/as-wasi": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/as-wasi/-/as-wasi-0.4.4.tgz",
-      "integrity": "sha512-CNeZ3AjKSjrFXRNDRzX1VzxsWz3Fwksn4g0J7tZv5RKz4agKhVlcl0QeMIOOkJms7DujCBCpbelGxNDtvlFKmw=="
-    },
-    "node_modules/assemblyscript": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.18.15.tgz",
-      "integrity": "sha512-s1N1qwdBhen2SLQApYCtRIPWm1Am3oAbW58GCEKbeN6ZbQRh7nq0pv4RDqKw6CgK7dySn/F2S1D6p0scyRbQRw==",
-      "dependencies": {
-        "binaryen": "100.0.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "asc": "bin/asc",
-        "asinit": "bin/asinit"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/assemblyscript"
-      }
-    },
-    "node_modules/binaryen": {
-      "version": "100.0.0",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-100.0.0.tgz",
-      "integrity": "sha512-nxOt8d8/VXAuSVEtAWUdKrqpqCy365QqD223EzzB1GzS5himiZAfM/R5lXx+M/5q8TB8cYp3tYxv5rTjNTJveQ==",
-      "bin": {
-        "wasm-opt": "bin/wasm-opt"
-      }
-    },
-    "node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    }
-  },
+  "lockfileVersion": 1,
   "dependencies": {
     "as-wasi": {
       "version": "0.4.4",

--- a/tests/rust/src/lib.rs
+++ b/tests/rust/src/lib.rs
@@ -7,8 +7,9 @@ pub extern "C" fn get() {
     let res = wasi_experimental_http::request(req).expect("cannot make get request");
 
     let str = std::str::from_utf8(&res.body()).unwrap().to_string();
-    assert_eq!(r#""OK""#, str);
+    assert_eq!(str, r#""OK""#);
     assert_eq!(res.status(), 200);
+    assert_eq!(res.headers().len(), 6);
 }
 
 #[no_mangle]
@@ -25,4 +26,5 @@ pub extern "C" fn post() {
     let res = wasi_experimental_http::request(req).expect("cannot make post request");
     let _ = std::str::from_utf8(&res.body()).unwrap().to_string();
     assert_eq!(res.status(), 200);
+    assert_eq!(res.headers().len(), 7);
 }

--- a/tests/rust/src/lib.rs
+++ b/tests/rust/src/lib.rs
@@ -8,7 +8,7 @@ pub extern "C" fn get() {
 
     let str = std::str::from_utf8(&res.body()).unwrap().to_string();
     assert_eq!(r#""OK""#, str);
-    // println!("{}", str);
+    assert_eq!(res.status(), 200);
 }
 
 #[no_mangle]
@@ -24,7 +24,5 @@ pub extern "C" fn post() {
 
     let res = wasi_experimental_http::request(req).expect("cannot make post request");
     let _ = std::str::from_utf8(&res.body()).unwrap().to_string();
-    // println!("{:#?}", res.headers());
-    // println!("{}", str);
-    // println!("{:#?}", res.status().to_string());
+    assert_eq!(res.status(), 200);
 }


### PR DESCRIPTION
This commit introduces a few changes to the way headers are handled
in AssemblyScript:

- fix the way headers are parsed in AssemblyScript.
Specifically, after the request headers were not sent as JSON anymore,
there was an additional pair of quotation marks for both header key and
value that wasn't properly escaped.

- remove the additional quotation pair and bring the AssemblyScript way 
of passing strings back in sync with the way this is done in Rust.

- update the response headers in AssemblyScript to be a
much easier to consume `Map<string, string>` rather than a plain string

- update the tests to check the response status and  number of headers 
returned by the server, and abort if any of them doesn't match.

cc @jedisct1 