### PR TITLE
Disable `allowed_hosts` by default

### DIFF
--- a/crates/wasi-experimental-http-wasmtime/readme.md
+++ b/crates/wasi-experimental-http-wasmtime/readme.md
@@ -23,8 +23,8 @@ wasi_experimental_http_wasmtime::link_http(&mut linker, None)?;
 
 The Wasmtime implementation also enables allowed domains - an optional and
 configurable list of domains or hosts that guest modules are allowed to send
-requests to. If `None` is passed, guest modules are allowed to access any domain
-or host. (Note that the hosts passed MUST have the protocol also specified -
-i.e. `https://my-domain.com`, or `http://192.168.0.1`, and if making requests to
-a subdomain, the subdomain MUST be in the allowed list. See the the library
-tests for more examples).
+requests to. If `None` or an empty vector is passed, guest modules are **NOT**
+allowed to make HTTP requests to any server. (Note that the hosts passed MUST
+have the protocol also specified - i.e. `https://my-domain.com`, or
+`http://192.168.0.1`, and if making requests to a subdomain, the subdomain MUST
+be in the allowed list. See the the library tests for more examples).

--- a/crates/wasi-experimental-http-wasmtime/src/lib.rs
+++ b/crates/wasi-experimental-http-wasmtime/src/lib.rs
@@ -11,7 +11,7 @@ use wasmtime::*;
 const ALLOC_FN: &str = "alloc";
 const MEMORY: &str = "memory";
 
-pub fn link_http(linker: &mut Linker, allowed_domains: Option<Vec<String>>) -> Result<(), Error> {
+pub fn link_http(linker: &mut Linker, allowed_hosts: Option<Vec<String>>) -> Result<(), Error> {
     linker.func(
         "wasi_experimental_http",
         "req",
@@ -93,7 +93,7 @@ pub fn link_http(linker: &mut Linker, allowed_domains: Option<Vec<String>>) -> R
                 }
             };
 
-            match is_allowed(&url, allowed_domains.as_ref()) {
+            match is_allowed(&url, allowed_hosts.as_ref()) {
                 Ok(e) => match e {
                     true => {}
                     false => {
@@ -288,7 +288,7 @@ fn is_allowed(url: &str, allowed_domains: Option<&Vec<String>>) -> Result<bool, 
             let a: Vec<&str> = allowed.iter().map(|u| u.host_str().unwrap()).collect();
             Ok(a.contains(&url_host.as_str()))
         }
-        None => Ok(true),
+        None => Ok(false),
     }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,8 @@ let wasi = Wasi::new(&store, ctx);
 wasi.add_to_linker(&mut linker)?;
 
 // link the experimental HTTP support
-wasi_experimental_http_wasmtime::link_http(&mut linker, None)?;
+let allowed_hosts = Some(vec!["https://postman-echo.com".to_string()]);
+wasi_experimental_http_wasmtime::link_http(&mut linker, allowed_hosts)?;
 ```
 
 Then, executing the module above will send the HTTP request and write the
@@ -79,13 +80,13 @@ wasi_experimental_http::write_guest_memory:: written 374 bytes
 "200 OK"
 ```
 
-The Wasmtime implementation also enables allowed domains - an optional and
+The Wasmtime implementation also enables allowed hosts - an optional and
 configurable list of domains or hosts that guest modules are allowed to send
-requests to. If `None` is passed, guest modules are allowed to access any domain
-or host. (Note that the hosts passed MUST have the protocol also specified -
-i.e. `https://my-domain.com`, or `http://192.168.0.1`, and if making requests to
-a subdomain, the subdomain MUST be in the allowed list. See the the library
-tests for more examples).
+requests to. If `None` or an empty vector is passed, guest modules are **NOT**
+allowed to make HTTP requests to any server. (Note that the hosts passed MUST
+have the protocol also specified - i.e. `https://my-domain.com`, or
+`http://192.168.0.1`, and if making requests to a subdomain, the subdomain MUST
+be in the allowed list. See the the library tests for more examples).
 
 Note that the Wasmtime version currently supported is
 [0.24](https://docs.rs/wasmtime/0.24.0/wasmtime/).

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11,12 +11,14 @@ mod tests {
     // in order to make sure both scenarios are working.
 
     #[test]
-    fn test_all_allowed() {
+    #[should_panic]
+    fn test_none_allowed() {
         setup_tests(None);
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_async_all_allowed() {
+    #[should_panic]
+    async fn test_async_none_allowed() {
         setup_tests(None);
     }
 


### PR DESCRIPTION
closes #37
depends on #38 

This commit renames `allowed_domains` to `allowed_hosts` and defaults
to NOT allowing guest modules to make HTTP requests when `None` is
the value passed.

This change brings the way this library handles its "capability" closer
to how upstream WASI works, while also making more sense (if `None` is
passed as value for `allowed_hosts`, modules are not allowed to send
requests).
