### PR TITLE
Bump package versions to 0.2

### DIFF
--- a/crates/as/package.json
+++ b/crates/as/package.json
@@ -3,7 +3,7 @@
   "main": "index.ts",
   "ascMain": "index.ts",
   "types": "index.ts",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Experimental HTTP library for AssemblyScript",
   "author": {
     "name": "The DeisLabs team at Microsoft"
@@ -21,7 +21,7 @@
     "asbuild": "asc index.ts -b build/optimized.wasm --use abort=wasi_abort --debug"
   },
   "dependencies": {
-    "as-wasi": "0.2.0",
+    "as-wasi": "0.4.4",
     "assemblyscript": "^0.18.12"
   }
 }

--- a/crates/wasi-experimental-http-wasmtime/Cargo.toml
+++ b/crates/wasi-experimental-http-wasmtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-experimental-http-wasmtime"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Radu Matei <radu.matei@microsoft.com>"]
 edition = "2018"
 repository = "https://github.com/deislabs/wasi-experimental-http"
@@ -19,5 +19,5 @@ url = "2.0"
 wasmtime = "0.24"
 wasmtime-wasi = "0.24"
 wasi-common = "0.24"
-wasi-experimental-http = { version = "0.1", path = "../wasi-experimental-http" }
+wasi-experimental-http = { version = "0.2", path = "../wasi-experimental-http" }
 tracing = { version = "0.1", features = ["log"] }

--- a/crates/wasi-experimental-http/Cargo.toml
+++ b/crates/wasi-experimental-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-experimental-http"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Radu Matei <radu.matei@microsoft.com>"]
 edition = "2018"
 repository = "https://github.com/deislabs/wasi-experimental-http"

--- a/readme.md
+++ b/readme.md
@@ -125,7 +125,6 @@ export function _start_(): void {
   modules have to wait until the entire body has been written by the runtime
   before reading it.
 - request and response bodies are [`Bytes`](https://docs.rs/bytes/1.0.1/bytes/).
-- handling headers in Rust is currently very inefficient.
 - there are no WITX definitions, which means we have to manually keep the host
   call and guest implementation in sync. Adding WITX definitions could also
   enable support for other WASI runtimes.


### PR DESCRIPTION
This PR updates the package versions to 0.2.

Note that the versions have already been published to crates.io and NPM:

- https://crates.io/crates/wasi-experimental-http
- https://crates.io/crates/wasi-experimental-http-wasmtime
- https://www.npmjs.com/package/@deislabs/wasi-experimental-http