### PR TITLE
Change the API to allow streaming & no callback to alloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ anyhow = "1.0"
 futures = "0.3"
 http = "0.2"
 reqwest = { version = "0.11", default-features = true, features = ["json", "blocking"] }
-tokio = { version = "1.1", features = ["full"] }
-wasmtime = "0.24"
-wasmtime-wasi = "0.24"
-wasi-common = "0.24"
-wasi-cap-std-sync = "0.24"
+tokio = { version = "1.4.0", features = ["full"] }
+wasmtime = "0.25.0"
+wasmtime-wasi = "0.25.0"
+wasi-common = "0.25.0"
+wasi-cap-std-sync = "0.25.0"
 wasi-experimental-http = { path = "crates/wasi-experimental-http" }
 wasi-experimental-http-wasmtime = { path = "crates/wasi-experimental-http-wasmtime" }
 

--- a/crates/as/package-lock.json
+++ b/crates/as/package-lock.json
@@ -1,26 +1,73 @@
 {
   "name": "@deislabs/wasi-experimental-http",
+  "version": "0.2.0",
+  "lockfileVersion": 2,
   "requires": true,
-  "lockfileVersion": 1,
+  "packages": {
+    "": {
+      "name": "@deislabs/wasi-experimental-http",
+      "version": "0.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "as-wasi": "0.4.4",
+        "assemblyscript": "^0.18.16"
+      }
+    },
+    "node_modules/as-wasi": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/as-wasi/-/as-wasi-0.4.4.tgz",
+      "integrity": "sha512-CNeZ3AjKSjrFXRNDRzX1VzxsWz3Fwksn4g0J7tZv5RKz4agKhVlcl0QeMIOOkJms7DujCBCpbelGxNDtvlFKmw=="
+    },
+    "node_modules/assemblyscript": {
+      "version": "0.18.18",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.18.18.tgz",
+      "integrity": "sha512-X8tcvrckuR8L8e2e85rxiBjvl1OXFx6KbHiHbC0eEHhr8R1DMBMdJbnoWRf50HU8UDqps6M+8tLXsannTI999w==",
+      "dependencies": {
+        "binaryen": "100.0.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "asc": "bin/asc",
+        "asinit": "bin/asinit"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/assemblyscript"
+      }
+    },
+    "node_modules/binaryen": {
+      "version": "100.0.0",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-100.0.0.tgz",
+      "integrity": "sha512-nxOt8d8/VXAuSVEtAWUdKrqpqCy365QqD223EzzB1GzS5himiZAfM/R5lXx+M/5q8TB8cYp3tYxv5rTjNTJveQ==",
+      "bin": {
+        "wasm-opt": "bin/wasm-opt"
+      }
+    },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    }
+  },
   "dependencies": {
     "as-wasi": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/as-wasi/-/as-wasi-0.2.0.tgz",
-      "integrity": "sha512-dQ9b0YXZx8B7t0BhGNKRbugZkyQY6dca3rOFQcoN/grlOYnPUygtYCdOKU2iLLtbCan+dgt9Ww1zgDxeRs9U/g=="
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/as-wasi/-/as-wasi-0.4.4.tgz",
+      "integrity": "sha512-CNeZ3AjKSjrFXRNDRzX1VzxsWz3Fwksn4g0J7tZv5RKz4agKhVlcl0QeMIOOkJms7DujCBCpbelGxNDtvlFKmw=="
     },
     "assemblyscript": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.18.12.tgz",
-      "integrity": "sha512-a0zJlb4xgEtxdadrrIP9MuLmQuRE6ZVzXPi2RZoVG6zgz+nLYLt1mkiP/TbJRY+4wvf1peTCZok+vyRAxFjppQ==",
+      "version": "0.18.18",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.18.18.tgz",
+      "integrity": "sha512-X8tcvrckuR8L8e2e85rxiBjvl1OXFx6KbHiHbC0eEHhr8R1DMBMdJbnoWRf50HU8UDqps6M+8tLXsannTI999w==",
       "requires": {
-        "binaryen": "98.0.0-nightly.20210106",
+        "binaryen": "100.0.0",
         "long": "^4.0.0"
       }
     },
     "binaryen": {
-      "version": "98.0.0-nightly.20210106",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-98.0.0-nightly.20210106.tgz",
-      "integrity": "sha512-iunAgesqT9PXVYCc72FA4h0sCCKLifruT6NuUH63xqlFJGpChhZLgOtyIb/fIgTibN5Pd692cxfBViyCWFsJ9Q=="
+      "version": "100.0.0",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-100.0.0.tgz",
+      "integrity": "sha512-nxOt8d8/VXAuSVEtAWUdKrqpqCy365QqD223EzzB1GzS5himiZAfM/R5lXx+M/5q8TB8cYp3tYxv5rTjNTJveQ=="
     },
     "long": {
       "version": "4.0.0",

--- a/crates/as/package.json
+++ b/crates/as/package.json
@@ -22,6 +22,6 @@
   },
   "dependencies": {
     "as-wasi": "0.4.4",
-    "assemblyscript": "^0.18.12"
+    "assemblyscript": "^0.18.16"
   }
 }

--- a/crates/as/readme.md
+++ b/crates/as/readme.md
@@ -22,7 +22,6 @@ import {
   RequestBuilder,
   Response,
 } from "@deislabs/wasi-experimental-http";
-export { alloc } from "@deislabs/wasi-experimental-http";
 
 export function post(): void {
   let body = String.UTF8.encode("testing the body");
@@ -32,14 +31,13 @@ export function post(): void {
     .body(body)
     .send();
 
-  let result = String.UTF8.decode(res.body);
   print(res);
 }
 
 function print(res: Response): void {
   Console.log(res.status.toString());
-  Console.log(res.headers);
-  let result = String.UTF8.decode(res.body);
+  Console.log(res.getHeader("Content-Type"));
+  let result = String.UTF8.decode(res.bodyReadAll().buffer);
   Console.log(result);
 }
 ```

--- a/crates/wasi-experimental-http-wasmtime/Cargo.toml
+++ b/crates/wasi-experimental-http-wasmtime/Cargo.toml
@@ -14,10 +14,11 @@ bytes = "1"
 futures = "0.3"
 http = "0.2"
 reqwest = { version = "0.11", default-features = true, features = ["json", "blocking"] }
-tokio = { version = "1.1", features = ["full"] }
-url = "2.0"
-wasmtime = "0.24"
-wasmtime-wasi = "0.24"
-wasi-common = "0.24"
+thiserror = "1.0"
+tokio = { version = "1.4.0", features = ["full"] }
+url = "2.2.1"
+wasmtime = "0.25"
+wasmtime-wasi = "0.25"
+wasi-common = "0.25"
 wasi-experimental-http = { version = "0.2", path = "../wasi-experimental-http" }
 tracing = { version = "0.1", features = ["log"] }

--- a/crates/wasi-experimental-http-wasmtime/readme.md
+++ b/crates/wasi-experimental-http-wasmtime/readme.md
@@ -7,7 +7,7 @@ Experimental HTTP library for WebAssembly in Wasmtime
 ### Adding support to a Wasmtime runtime
 
 The easiest way to add support is by using the
-[Wasmtime linker](https://docs.rs/wasmtime/0.24.0/wasmtime/struct.Linker.html):
+[Wasmtime linker](https://docs.rs/wasmtime/0.25.0/wasmtime/struct.Linker.html):
 
 ```rust
 let store = Store::default();
@@ -18,7 +18,8 @@ let wasi = Wasi::new(&store, ctx);
 wasi.add_to_linker(&mut linker)?;
 
 // link the experimental HTTP support
-wasi_experimental_http_wasmtime::link_http(&mut linker, None)?;
+let http = Http::new(None);
+http.add_to_linker(&mut linker)?;
 ```
 
 The Wasmtime implementation also enables allowed domains - an optional and

--- a/crates/wasi-experimental-http-wasmtime/src/lib.rs
+++ b/crates/wasi-experimental-http-wasmtime/src/lib.rs
@@ -3,183 +3,365 @@ use bytes::Bytes;
 use futures::executor::block_on;
 use http::{HeaderMap, HeaderValue};
 use reqwest::{Client, Method};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
 use std::str::FromStr;
 use tokio::runtime::Handle;
 use url::Url;
 use wasmtime::*;
 
-const ALLOC_FN: &str = "alloc";
 const MEMORY: &str = "memory";
 
-pub fn link_http(linker: &mut Linker, allowed_hosts: Option<Vec<String>>) -> Result<(), Error> {
-    linker.func(
-        "wasi_experimental_http",
-        "req",
-        move |caller: Caller<'_>,
-              url_ptr: u32,
-              url_len: u32,
-              method_ptr: u32,
-              method_len: u32,
-              req_body: u32,
-              req_body_len: u32,
-              headers_ptr: u32,
-              headers_len: u32,
-              body_res_ptr: u32,
-              body_written_ptr: u32,
-              headers_res_ptr: u32,
-              headers_written_ptr: u32,
-              status_code_ptr: u32,
-              err_ptr: u32,
-              err_written_ptr: u32|
-              -> u32 {
-            let span = tracing::trace_span!("req");
-            let _enter = span.enter();
-            // Get the module's memory and allocation function.
-            // If either is not found, the runtime cannot write any response
-            // data, so the execution cannot continue.
-            tracing::trace!(export = MEMORY, "getting export");
-            let memory = match caller.get_export(MEMORY) {
-                Some(Extern::Memory(mem)) => mem,
-                _ => {
-                    return err(
-                        "cannot find memory".to_string(),
-                        None,
-                        None,
-                        err_ptr,
-                        err_written_ptr,
-                        1,
-                    )
-                }
-            };
-            tracing::trace!(export = ALLOC_FN, "getting export");
-            let alloc = match caller.get_export(ALLOC_FN) {
-                Some(Extern::Func(func)) => func,
-                _ => {
-                    return err(
-                        "cannot find alloc function".to_string(),
-                        None,
-                        None,
-                        err_ptr,
-                        err_written_ptr,
-                        1,
-                    )
-                }
-            };
+pub type WasiHandle = u32;
 
-            // Get the URL, headers, method, and request body from the module's memory.
-            let (url, headers, method, req_body) = match unsafe {
-                http_parts_from_memory(
-                    &memory,
+struct Body {
+    bytes: Vec<u8>,
+    pos: usize,
+}
+
+struct Response {
+    headers: HeaderMap,
+    body: Body,
+}
+
+#[derive(Default)]
+pub struct State {
+    responses: HashMap<WasiHandle, Response>,
+    current_handle: WasiHandle,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum HttpError {
+    #[error("Invalid handle: [{0}]")]
+    InvalidHandle(WasiHandle),
+    #[error("Memory not found")]
+    MemoryNotFound,
+    #[error("Memory access error")]
+    MemoryAccessError(#[from] wasmtime::MemoryAccessError),
+    #[error("Buffer too small")]
+    BufferTooSmall,
+    #[error("Header not found")]
+    HeaderNotFound,
+    #[error("UTF-8 error")]
+    UTF8Error(#[from] std::str::Utf8Error),
+    #[error("Destination not allowed")]
+    DestinationNotAllowed(String),
+    #[error("Invalid method")]
+    InvalidMethod,
+    #[error("Invalid encoding")]
+    InvalidEncoding,
+    #[error("Invalid URL")]
+    InvalidUrl,
+    #[error("HTTP error")]
+    RequestError(#[from] reqwest::Error),
+    #[error("Runtime error")]
+    RuntimeError,
+    #[error("Too many sessions")]
+    TooManySessions,
+}
+
+impl From<HttpError> for u32 {
+    fn from(e: HttpError) -> u32 {
+        match e {
+            HttpError::InvalidHandle(_) => 1,
+            HttpError::MemoryNotFound => 2,
+            HttpError::MemoryAccessError(_) => 3,
+            HttpError::BufferTooSmall => 4,
+            HttpError::HeaderNotFound => 5,
+            HttpError::UTF8Error(_) => 6,
+            HttpError::DestinationNotAllowed(_) => 7,
+            HttpError::InvalidMethod => 8,
+            HttpError::InvalidEncoding => 9,
+            HttpError::InvalidUrl => 10,
+            HttpError::RequestError(_) => 11,
+            HttpError::RuntimeError => 12,
+            HttpError::TooManySessions => 13,
+        }
+    }
+}
+
+fn memory_get(caller: Caller<'_>) -> Result<Memory, HttpError> {
+    if let Some(Extern::Memory(mem)) = caller.get_export(MEMORY) {
+        Ok(mem)
+    } else {
+        Err(HttpError::MemoryNotFound)
+    }
+}
+
+fn slice_from_memory(memory: &Memory, offset: u32, len: u32) -> Result<&[u8], HttpError> {
+    let required_memory_size = offset.checked_add(len).ok_or(HttpError::BufferTooSmall)? as usize;
+    if required_memory_size > memory.data_size() {
+        return Err(HttpError::BufferTooSmall);
+    }
+    let slice =
+        &unsafe { memory.data_unchecked() }[offset as usize..offset as usize + len as usize];
+    Ok(slice)
+}
+
+fn string_from_memory(memory: &Memory, offset: u32, len: u32) -> Result<&str, HttpError> {
+    let slice = slice_from_memory(memory, offset, len)?;
+    Ok(std::str::from_utf8(slice)?)
+}
+
+struct HostCalls;
+
+impl HostCalls {
+    fn close(
+        st: Rc<RefCell<State>>,
+        _caller: Caller<'_>,
+        handle: WasiHandle,
+    ) -> Result<(), HttpError> {
+        st.borrow_mut().responses.remove(&handle);
+        Ok(())
+    }
+
+    fn body_read(
+        st: Rc<RefCell<State>>,
+        caller: Caller<'_>,
+        handle: WasiHandle,
+        buf_ptr: u32,
+        buf_len: u32,
+        buf_read_ptr: u32,
+    ) -> Result<(), HttpError> {
+        let mut st = st.borrow_mut();
+        let mut body = &mut st
+            .responses
+            .get_mut(&handle)
+            .ok_or(HttpError::InvalidHandle(handle))?
+            .body;
+        let memory = memory_get(caller)?;
+        let available = std::cmp::min(buf_len as _, body.bytes.len() - body.pos);
+        memory.write(buf_ptr as _, &body.bytes[body.pos..body.pos + available])?;
+        body.pos += available;
+        memory.write(buf_read_ptr as _, &(available as u32).to_le_bytes())?;
+        Ok(())
+    }
+
+    fn header_get(
+        st: Rc<RefCell<State>>,
+        caller: Caller<'_>,
+        handle: WasiHandle,
+        name_ptr: u32,
+        name_len: u32,
+        value_ptr: u32,
+        value_len: u32,
+        value_written_ptr: u32,
+    ) -> Result<(), HttpError> {
+        let st = st.borrow();
+        let headers = &st
+            .responses
+            .get(&handle)
+            .ok_or(HttpError::InvalidHandle(handle))?
+            .headers;
+        let memory = memory_get(caller)?;
+        let key = string_from_memory(&memory, name_ptr, name_len)?.to_ascii_lowercase();
+        let value = headers.get(key).ok_or(HttpError::HeaderNotFound)?;
+        if value.len() > value_len as _ {
+            return Err(HttpError::BufferTooSmall);
+        }
+        memory.write(value_ptr as _, value.as_bytes())?;
+        memory.write(value_written_ptr as _, &(value.len() as u32).to_le_bytes())?;
+        Ok(())
+    }
+
+    fn req(
+        st: Rc<RefCell<State>>,
+        allowed_hosts: Option<&[String]>,
+        caller: Caller<'_>,
+        url_ptr: u32,
+        url_len: u32,
+        method_ptr: u32,
+        method_len: u32,
+        req_headers_ptr: u32,
+        req_headers_len: u32,
+        req_body_ptr: u32,
+        req_body_len: u32,
+        status_code_ptr: u32,
+        res_handle_ptr: u32,
+    ) -> Result<(), HttpError> {
+        let span = tracing::trace_span!("req");
+        let _enter = span.enter();
+        let memory = memory_get(caller)?;
+        let url = string_from_memory(&memory, url_ptr, url_len)?;
+        let method = Method::from_str(string_from_memory(&memory, method_ptr, method_len)?)
+            .map_err(|_| HttpError::InvalidMethod)?;
+        let req_body = slice_from_memory(&memory, req_body_ptr, req_body_len)?;
+        let headers = wasi_experimental_http::string_to_header_map(string_from_memory(
+            &memory,
+            req_headers_ptr,
+            req_headers_len,
+        )?)
+        .map_err(|_| HttpError::InvalidEncoding)?;
+
+        if !is_allowed(url, allowed_hosts)? {
+            return Err(HttpError::DestinationNotAllowed(url.to_string()));
+        }
+
+        let (status, resp_headers, resp_body) = request(url, headers, method, req_body)?;
+        tracing::debug!(
+            status,
+            ?resp_headers,
+            body_len = resp_body.as_ref().len(),
+            "got HTTP response, writing back to memory"
+        );
+
+        memory.write(status_code_ptr as _, &status.to_le_bytes())?;
+
+        let response = Response {
+            headers: resp_headers,
+            body: Body {
+                bytes: resp_body.to_vec(),
+                pos: 0,
+            },
+        };
+        let mut st = st.borrow_mut();
+        let initial_handle = st.current_handle;
+        while st.responses.get(&st.current_handle).is_some() {
+            st.current_handle += 1;
+            if st.current_handle == initial_handle {
+                return Err(HttpError::TooManySessions);
+            }
+        }
+        let handle = st.current_handle;
+        st.responses.insert(handle, response);
+        memory.write(res_handle_ptr as _, &handle.to_le_bytes())?;
+
+        Ok(())
+    }
+}
+
+pub struct Http {
+    state: Rc<RefCell<State>>,
+    allowed_hosts: Rc<Option<Vec<String>>>,
+}
+
+impl Http {
+    pub const MODULE: &'static str = "wasi_experimental_http";
+
+    pub fn new(allowed_hosts: Option<Vec<String>>) -> Result<Self, Error> {
+        let state = Rc::new(RefCell::new(State::default()));
+        let allowed_hosts = Rc::new(allowed_hosts);
+        Ok(Http {
+            state,
+            allowed_hosts,
+        })
+    }
+
+    pub fn add_to_linker(&self, linker: &mut Linker) -> Result<(), Error> {
+        let st = self.state.clone();
+        linker.func(
+            Self::MODULE,
+            "close",
+            move |caller: Caller<'_>, handle: WasiHandle| -> u32 {
+                match HostCalls::close(st.clone(), caller, handle) {
+                    Ok(()) => 0,
+                    Err(e) => e.into(),
+                }
+            },
+        )?;
+
+        let st = self.state.clone();
+        linker.func(
+            Self::MODULE,
+            "body_read",
+            move |caller: Caller<'_>,
+                  handle: WasiHandle,
+                  buf_ptr: u32,
+                  buf_len: u32,
+                  buf_read_ptr: u32|
+                  -> u32 {
+                match HostCalls::body_read(
+                    st.clone(),
+                    caller,
+                    handle,
+                    buf_ptr,
+                    buf_len,
+                    buf_read_ptr,
+                ) {
+                    Ok(()) => 0,
+                    Err(e) => e.into(),
+                }
+            },
+        )?;
+
+        let st = self.state.clone();
+        linker.func(
+            Self::MODULE,
+            "header_get",
+            move |caller: Caller<'_>,
+                  handle: WasiHandle,
+                  name_ptr: u32,
+                  name_len: u32,
+                  value_ptr: u32,
+                  value_len: u32,
+                  value_written_ptr: u32|
+                  -> u32 {
+                match HostCalls::header_get(
+                    st.clone(),
+                    caller,
+                    handle,
+                    name_ptr,
+                    name_len,
+                    value_ptr,
+                    value_len,
+                    value_written_ptr,
+                ) {
+                    Ok(()) => 0,
+                    Err(e) => e.into(),
+                }
+            },
+        )?;
+
+        let st = self.state.clone();
+        let allowed_hosts = self.allowed_hosts.clone();
+        linker.func(
+            Self::MODULE,
+            "req",
+            move |caller: Caller<'_>,
+                  url_ptr: u32,
+                  url_len: u32,
+                  method_ptr: u32,
+                  method_len: u32,
+                  req_headers_ptr: u32,
+                  req_headers_len: u32,
+                  req_body_ptr: u32,
+                  req_body_len: u32,
+                  status_code_ptr: u32,
+                  res_handle_ptr: u32|
+                  -> u32 {
+                match HostCalls::req(
+                    st.clone(),
+                    allowed_hosts.as_deref(),
+                    caller,
                     url_ptr,
                     url_len,
                     method_ptr,
                     method_len,
-                    req_body,
+                    req_headers_ptr,
+                    req_headers_len,
+                    req_body_ptr,
                     req_body_len,
-                    headers_ptr,
-                    headers_len,
-                )
-            } {
-                Ok(r) => (r.0, r.1, r.2, r.3),
-                Err(_) => {
-                    return err(
-                        "cannot get HTTP parts from memory".to_string(),
-                        Some(&memory),
-                        Some(&alloc),
-                        err_ptr,
-                        err_written_ptr,
-                        4,
-                    )
-                }
-            };
-
-            match is_allowed(&url, allowed_hosts.as_ref()) {
-                Ok(e) => match e {
-                    true => {}
-                    false => {
-                        return err(
-                            format!(
-                            "URL {} not allowed because domain or subdomain not in allowed list",
-                            url
-                        ),
-                            Some(&memory),
-                            Some(&alloc),
-                            err_ptr,
-                            err_written_ptr,
-                            4,
-                        )
-                    }
-                },
-                Err(e) => {
-                    return err(
-                        e.to_string(),
-                        Some(&memory),
-                        Some(&alloc),
-                        err_ptr,
-                        err_written_ptr,
-                        4,
-                    )
-                }
-            };
-
-            let (status, headers, body) = match request(url, headers, method, req_body) {
-                Ok(r) => (r.0, r.1, r.2),
-                Err(e) => {
-                    return err(
-                        e.to_string(),
-                        Some(&memory),
-                        Some(&alloc),
-                        err_ptr,
-                        err_written_ptr,
-                        3,
-                    )
-                }
-            };
-            tracing::debug!(
-                status,
-                ?headers,
-                body_len = body.as_ref().len(),
-                "got HTTP response, writing back to memory"
-            );
-
-            // Write the HTTP response back to the module's memory.
-            unsafe {
-                match write_http_response_to_memory(
-                    status,
-                    headers,
-                    body,
-                    memory.clone(),
-                    alloc.clone(),
-                    headers_written_ptr,
-                    headers_res_ptr,
-                    body_res_ptr,
                     status_code_ptr,
-                    body_written_ptr,
+                    res_handle_ptr,
                 ) {
-                    Ok(_) => 0,
-                    Err(e) => err(
-                        e.to_string(),
-                        Some(&memory),
-                        Some(&alloc),
-                        err_ptr,
-                        err_written_ptr,
-                        3,
-                    ),
+                    Ok(()) => 0,
+                    Err(e) => e.into(),
                 }
-            }
-        },
-    )?;
+            },
+        )?;
 
-    Ok(())
+        Ok(())
+    }
 }
 
 #[tracing::instrument]
 fn request(
-    url: String,
+    url: &str,
     headers: HeaderMap,
     method: Method,
-    body: Vec<u8>,
-) -> Result<(u16, HeaderMap<HeaderValue>, Bytes), Error> {
+    body: &[u8],
+) -> Result<(u16, HeaderMap<HeaderValue>, Bytes), HttpError> {
     tracing::debug!(
         %url,
         ?headers,
@@ -187,6 +369,8 @@ fn request(
         body_len = body.len(),
         "performing request"
     );
+    let url: Url = url.parse().map_err(|_| HttpError::InvalidUrl)?;
+    let body = body.to_vec();
     match Handle::try_current() {
         Ok(r) => {
             // If running in a Tokio runtime, spawn a new blocking executor
@@ -202,23 +386,23 @@ fn request(
                 let client = Client::builder().build().unwrap();
                 let res = block_on(
                     client
-                        .request(method, &url)
+                        .request(method, url)
                         .headers(headers)
                         .body(body)
                         .send(),
                 )?;
-
-                return Ok((
+                Ok((
                     res.status().as_u16(),
                     res.headers().clone(),
                     block_on(res.bytes())?,
-                ));
-            }))?
+                ))
+            }))
+            .map_err(|_| HttpError::RuntimeError)?
         }
         Err(_) => {
             tracing::trace!("no tokio runtime available, using blocking request");
             let res = reqwest::blocking::Client::new()
-                .request(method, &url)
+                .request(method, url)
                 .headers(headers)
                 .body(body)
                 .send()?;
@@ -227,168 +411,21 @@ fn request(
     }
 }
 
-/// Get the URL, method, request body, and headers from the
-/// module's memory.
-#[allow(clippy::too_many_arguments)]
-unsafe fn http_parts_from_memory(
-    memory: &Memory,
-    url_ptr: u32,
-    url_len: u32,
-    method_ptr: u32,
-    method_len: u32,
-    req_body_ptr: u32,
-    req_body_len: u32,
-    headers_ptr: u32,
-    headers_len: u32,
-) -> Result<(String, HeaderMap, Method, Vec<u8>), Error> {
-    let url = string_from_memory(&memory, url_ptr, url_len)?;
-    let headers = string_from_memory(&memory, headers_ptr, headers_len)?;
-    let headers = wasi_experimental_http::string_to_header_map(&headers)?;
-    let method = string_from_memory(&memory, method_ptr, method_len)?;
-    let method = Method::from_str(&method)?;
-    let req_body = vec_from_memory(&memory, req_body_ptr, req_body_len);
-
-    Ok((url, headers, method, req_body))
-}
-
-/// Write the response data to the module's memory.
-#[allow(clippy::too_many_arguments)]
-unsafe fn write_http_response_to_memory(
-    status: u16,
-    headers: HeaderMap,
-    res: Bytes,
-    memory: Memory,
-    alloc: Func,
-    headers_written_ptr: u32,
-    headers_res_ptr: u32,
-    body_res_ptr: u32,
-    status_code_ptr: u32,
-    body_written_ptr: u32,
-) -> Result<(), Error> {
-    let hs = wasi_experimental_http::header_map_to_string(&headers)?;
-    // Write the response headers.
-    write(&hs, headers_res_ptr, headers_written_ptr, &memory, &alloc)?;
-
-    // Write the status code pointer.
-    let status_tmp_ptr = memory.data_ptr().offset(status_code_ptr as isize) as *mut u16;
-    *status_tmp_ptr = status;
-
-    // Write the response body.
-    write(&res, body_res_ptr, body_written_ptr, &memory, &alloc)?;
-
-    Ok(())
-}
-
-fn is_allowed(url: &str, allowed_domains: Option<&Vec<String>>) -> Result<bool, Error> {
-    let url_host = Url::parse(url)?.host_str().unwrap().to_owned();
+fn is_allowed(url: &str, allowed_domains: Option<&[String]>) -> Result<bool, HttpError> {
+    let url_host = Url::parse(url)
+        .map_err(|_| HttpError::InvalidUrl)?
+        .host_str()
+        .ok_or(HttpError::InvalidUrl)?
+        .to_owned();
     match allowed_domains {
         Some(domains) => {
             let allowed: Result<Vec<_>, _> = domains.iter().map(|d| Url::parse(d)).collect();
-            let allowed = allowed?;
+            let allowed = allowed.map_err(|_| HttpError::InvalidUrl)?;
             let a: Vec<&str> = allowed.iter().map(|u| u.host_str().unwrap()).collect();
             Ok(a.contains(&url_host.as_str()))
         }
         None => Ok(false),
     }
-}
-
-/// Write error details into the module's memory and return.
-fn err(
-    msg: String,
-    memory: Option<&Memory>,
-    alloc: Option<&Func>,
-    err_ptr: u32,
-    err_len_ptr: u32,
-    err_code: u32,
-) -> u32 {
-    let memory = match memory {
-        Some(m) => m,
-        None => return err_code,
-    };
-    let alloc = match alloc {
-        Some(a) => a,
-        None => return err_code,
-    };
-    let _ = write(&msg, err_ptr, err_len_ptr, memory, alloc);
-    err_code
-}
-
-/// Read a byte array from the instance's `memory`  of length `len_ptr`
-/// starting at offset `data_ptr`
-unsafe fn data_from_memory(memory: &Memory, data_ptr: u32, len: u32) -> (Option<&[u8]>, u32) {
-    println!("wasi_experimental_http::data_from_memory:: length: {}", len);
-
-    let data = memory
-        .data_unchecked()
-        .get(data_ptr as u32 as usize..)
-        .and_then(|arr| arr.get(..len as u32 as usize));
-
-    (data, len)
-}
-
-/// Get a `Vec<u8>` from the module's memory.
-unsafe fn vec_from_memory(memory: &Memory, data_ptr: u32, len_ptr: u32) -> Vec<u8> {
-    let (data, _) = data_from_memory(&memory, data_ptr, len_ptr);
-    // Normally, this should never panic.
-    data.unwrap_or_default().to_vec()
-}
-
-/// Read a string from the instance's `memory`  of length `len`
-/// starting at offset `data_ptr`
-unsafe fn string_from_memory(
-    memory: &Memory,
-    data_ptr: u32,
-    len: u32,
-) -> Result<String, anyhow::Error> {
-    let (data, _) = data_from_memory(&memory, data_ptr, len);
-    let str = match data {
-        Some(data) => match std::str::from_utf8(data) {
-            Ok(s) => s,
-            Err(_) => return Err(anyhow::Error::msg("invalid utf-8")),
-        },
-        None => return Err(anyhow::Error::msg("pointer/length out of bounds")),
-    };
-
-    Ok(String::from(str))
-}
-
-/// Write a byte array into the instance's linear memory
-/// and return the offset relative to the module's memory.
-fn write(
-    data: impl AsRef<[u8]>,
-    ptr: u32,
-    bytes_written_ptr: u32,
-    memory: &Memory,
-    alloc: &Func,
-) -> Result<(), Error> {
-    let bytes = data.as_ref();
-    let alloc_result = alloc.call(&[Val::from(bytes.len() as i32)])?;
-    let guest_ptr_offset = match alloc_result
-        .get(0)
-        .expect("expected the result of the allocation to have one value")
-    {
-        Val::I32(val) => *val as isize,
-        _ => return Err(Error::msg("guest pointer must be Val::I32")),
-    };
-    unsafe {
-        let raw = memory.data_ptr().offset(guest_ptr_offset);
-        raw.copy_from(bytes.as_ptr(), bytes.len());
-
-        // Get the offsite to `written` in the module's memory and set its value
-        // to the number of body bytes written.
-        let written_ptr = memory.data_ptr().offset(bytes_written_ptr as isize) as *mut u32;
-        *written_ptr = bytes.len() as u32;
-        println!(
-            "wasi_experimental_http::write_guest_memory:: written {} bytes",
-            *written_ptr
-        );
-
-        // Write result pointer.
-        let res_ptr = memory.data_ptr().offset(ptr as isize) as *mut u32;
-        *res_ptr = guest_ptr_offset as u32;
-    }
-
-    Ok(())
 }
 
 #[test]

--- a/crates/wasi-experimental-http-wasmtime/src/lib.rs
+++ b/crates/wasi-experimental-http-wasmtime/src/lib.rs
@@ -26,7 +26,7 @@ struct Response {
 }
 
 #[derive(Default)]
-pub struct State {
+struct State {
     responses: HashMap<WasiHandle, Response>,
     current_handle: WasiHandle,
 }
@@ -231,14 +231,19 @@ impl HostCalls {
     }
 }
 
+/// Experiment HTTP extension object for wasmtime.
 pub struct Http {
     state: Rc<RefCell<State>>,
     allowed_hosts: Rc<Option<Vec<String>>>,
 }
 
 impl Http {
+    /// Module the HTTP extension is going to be defined as.
     pub const MODULE: &'static str = "wasi_experimental_http";
 
+    /// Create a new HTTP extension object.
+    /// `allowed_hosts` may be `None` (no outbound connections allowed)
+    /// or a list of allowed host names.
     pub fn new(allowed_hosts: Option<Vec<String>>) -> Result<Self, Error> {
         let state = Rc::new(RefCell::new(State::default()));
         let allowed_hosts = Rc::new(allowed_hosts);
@@ -248,6 +253,7 @@ impl Http {
         })
     }
 
+    /// Register the module with the wasmtime linker.
     pub fn add_to_linker(&self, linker: &mut Linker) -> Result<(), Error> {
         let st = self.state.clone();
         linker.func(

--- a/crates/wasi-experimental-http/Cargo.toml
+++ b/crates/wasi-experimental-http/Cargo.toml
@@ -12,4 +12,5 @@ readme = "readme.md"
 anyhow = "1.0"
 bytes = "1"
 http = "0.2"
+thiserror = "1.0"
 tracing = { version = "0.1", features = ["log"] }

--- a/crates/wasi-experimental-http/src/lib.rs
+++ b/crates/wasi-experimental-http/src/lib.rs
@@ -1,25 +1,153 @@
 use anyhow::Error;
 use bytes::Bytes;
-use http::{self, header::HeaderName, HeaderMap, HeaderValue, Request, Response, StatusCode};
+use http::{self, header::HeaderName, HeaderMap, HeaderValue, Request, StatusCode};
 use std::str::FromStr;
 
-/// Create an HTTP request and get an HTTP response.
-/// Currently, both the request and response bodies have to be `Vec<u8>`.
+#[derive(Debug, thiserror::Error)]
+enum HttpError {
+    #[error("Invalid handle")]
+    InvalidHandle,
+    #[error("Memory not found")]
+    MemoryNotFound,
+    #[error("Memory access error")]
+    MemoryAccessError,
+    #[error("Buffer too small")]
+    BufferTooSmall,
+    #[error("Header not found")]
+    HeaderNotFound,
+    #[error("UTF-8 error")]
+    UTF8Error,
+    #[error("Destination not allowed")]
+    DestinationNotAllowed,
+    #[error("Invalid method")]
+    InvalidMethod,
+    #[error("Invalid encoding")]
+    InvalidEncoding,
+    #[error("Invalid URL")]
+    InvalidUrl,
+    #[error("HTTP error")]
+    RequestError,
+    #[error("Runtime error")]
+    RuntimeError,
+    #[error("Too many sessions")]
+    TooManySessions,
+}
+
+fn raw_err_check(e: u32) -> Result<(), HttpError> {
+    match e {
+        0 => Ok(()),
+        1 => Err(HttpError::InvalidHandle),
+        2 => Err(HttpError::MemoryNotFound),
+        3 => Err(HttpError::MemoryAccessError),
+        4 => Err(HttpError::BufferTooSmall),
+        5 => Err(HttpError::HeaderNotFound),
+        6 => Err(HttpError::UTF8Error),
+        7 => Err(HttpError::DestinationNotAllowed),
+        8 => Err(HttpError::InvalidMethod),
+        9 => Err(HttpError::InvalidEncoding),
+        10 => Err(HttpError::InvalidUrl),
+        11 => Err(HttpError::RequestError),
+        12 => Err(HttpError::RuntimeError),
+        13 => Err(HttpError::TooManySessions),
+        _ => unreachable!(),
+    }
+}
+
+pub type Handle = u32;
+
+pub struct Response {
+    handle: Handle,
+    pub status_code: StatusCode,
+}
+
+impl Drop for Response {
+    fn drop(&mut self) {
+        unsafe { raw::close(self.handle) };
+    }
+}
+
+impl Response {
+    pub fn body_read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+        let mut read: usize = 0;
+        let ret = unsafe { raw::body_read(self.handle, buf.as_mut_ptr(), buf.len(), &mut read) };
+        raw_err_check(ret)?;
+        Ok(read)
+    }
+
+    pub fn body_read_all(&mut self) -> Result<Vec<u8>, Error> {
+        let mut chunk = [0u8; 4096];
+        let mut v = vec![];
+        loop {
+            let read = self.body_read(&mut chunk)?;
+            if read == 0 {
+                return Ok(v);
+            }
+            v.extend_from_slice(&chunk[0..read]);
+        }
+    }
+
+    pub fn header_get(&self, name: &str) -> Result<String, Error> {
+        let mut capacity = 4096;
+        loop {
+            let mut written: usize = 0;
+            let mut buf = vec![0u8; capacity];
+            let ret = unsafe {
+                raw::header_get(
+                    self.handle,
+                    name.as_ptr(),
+                    name.len(),
+                    buf.as_mut_ptr(),
+                    buf.len(),
+                    &mut written,
+                )
+            };
+            match raw_err_check(ret) {
+                Ok(()) => {
+                    buf.truncate(written);
+                    return Ok(String::from_utf8(buf)?);
+                }
+                Err(HttpError::BufferTooSmall) => {
+                    capacity *= 2;
+                    continue;
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+    }
+}
+
 #[tracing::instrument]
-pub fn request(req: Request<Option<Bytes>>) -> Result<Response<Bytes>, Error> {
+pub fn request(req: Request<Option<Bytes>>) -> Result<Response, Error> {
     let url = req.uri().to_string();
     tracing::debug!(%url, headers = ?req.headers(), "performing http request using wasmtime function");
-    let headers = header_map_to_string(req.headers())?;
-    let (body, headers, status_code) =
-        unsafe { raw_request(&url, req.method().to_string(), &headers, req.body())? };
-    let mut res = Response::builder().status(StatusCode::from_u16(status_code)?);
-    append_headers(
-        res.headers_mut().unwrap(),
-        std::str::from_utf8(&headers)?.to_string(),
-    )?;
-    tracing::debug!(status_code, headers = ?res.headers_ref().unwrap(), body_len = body.len(), "got http response");
 
-    Ok(res.body(Bytes::from(body))?)
+    let headers = header_map_to_string(req.headers())?;
+    let method = req.method().as_str();
+    let body = match req.body() {
+        None => Default::default(),
+        Some(body) => body.as_ref(),
+    };
+    let mut status_code: u16 = 0;
+    let mut handle: Handle = 0;
+    let ret = unsafe {
+        raw::req(
+            url.as_ptr(),
+            url.len(),
+            method.as_ptr(),
+            method.len(),
+            headers.as_ptr(),
+            headers.len(),
+            body.as_ptr(),
+            body.len(),
+            &mut status_code,
+            &mut handle,
+        )
+    };
+    raw_err_check(ret)?;
+    Ok(Response {
+        handle,
+        status_code: StatusCode::from_u16(status_code)?,
+    })
 }
 
 pub fn header_map_to_string(hm: &HeaderMap) -> Result<String, Error> {
@@ -58,158 +186,41 @@ pub fn string_to_header_map(s: &str) -> Result<HeaderMap, Error> {
     Ok(headers)
 }
 
-/// Append a header map string to a mutable http::HeaderMap.
-fn append_headers(res_headers: &mut HeaderMap, source: String) -> Result<(), Error> {
-    res_headers.extend(string_to_header_map(&source)?);
-    Ok(())
-}
+mod raw {
+    /// Import `wasi_experimental_http` from the runtime.
+    #[link(wasm_import_module = "wasi_experimental_http")]
+    extern "C" {
+        pub fn req(
+            url_ptr: *const u8,
+            url_len_ptr: usize,
+            method_ptr: *const u8,
+            method_len_ptr: usize,
+            req_headers_ptr: *const u8,
+            req_headers_len_ptr: usize,
+            req_body_ptr: *const u8,
+            req_body_len_ptr: usize,
+            status_code_ptr: *mut u16,
+            res_handle_ptr: *mut u32,
+        ) -> u32;
 
-/// Transform an http::Request into raw parts and make an FFI function call
-/// to the underlying WebAssembly runtime.
-/// Note that the runtime MUST support this library, otherwise, the module
-/// will not be instantiated.
-unsafe fn raw_request(
-    url: &str,
-    method: String,
-    headers: &str,
-    body: &Option<Bytes>,
-) -> Result<(Vec<u8>, Vec<u8>, u16), Error> {
-    let body = match body {
-        Some(b) => b.to_vec(),
-        None => Vec::new(),
-    };
+        pub fn close(handle: u32) -> u32;
 
-    // Get pointers and lengths from the incoming requests' URL,
-    // method, headers, and body.
+        pub fn header_get(
+            handle: u32,
+            name_ptr: *const u8,
+            name_len: usize,
+            value_ptr: *mut u8,
+            value_len: usize,
+            value_written_ptr: *mut usize,
+        ) -> u32;
 
-    let req_body_ptr = body.as_ptr();
-    let req_body_len_ptr = body.len();
-
-    let method_ptr = method.as_bytes().as_ptr();
-    let method_len_ptr = method.len();
-
-    let url_ptr = url.as_bytes().as_ptr();
-    let url_len_ptr = url.len();
-
-    let headers_ptr = headers.as_bytes().as_ptr();
-    let headers_len_ptr = headers.len();
-
-    // Create raw pointers that the runtime will write information about
-    // the response, headers, status code, and error into.
-
-    let body_res_ptr = raw_string_ptr();
-    let body_written_ptr = raw_ptr();
-
-    let headers_res_ptr = raw_string_ptr();
-    let headers_written_ptr = raw_ptr();
-
-    let status_code_ptr = raw_ptr();
-
-    let err_ptr = raw_string_ptr();
-    let err_written_ptr = raw_ptr();
-
-    // Make a host function call, which will write the required data
-    // in the memory, or return an error code (potentially with some more
-    // error details).
-    let err = req(
-        url_ptr,
-        url_len_ptr,
-        method_ptr,
-        method_len_ptr,
-        req_body_ptr,
-        req_body_len_ptr,
-        headers_ptr,
-        headers_len_ptr,
-        body_res_ptr,
-        body_written_ptr,
-        headers_res_ptr,
-        headers_written_ptr,
-        status_code_ptr,
-        err_ptr,
-        err_written_ptr,
-    );
-
-    // If the returned error is not 0, return it.
-    if err != 0 {
-        tracing::error!(error_code = err, "got error code from response");
-        // Depending on the error, the runtime might have not been able to
-        // actually write any details (if the module didn't export a memory
-        // or alloc function, for example).
-        if err == 1 {
-            return Err(Error::msg("cannot find memory or alloc function"));
-        }
-
-        let bytes = Vec::from_raw_parts(
-            *err_ptr as *mut u8,
-            *err_written_ptr as usize,
-            *err_written_ptr as usize,
-        );
-        let msg = std::str::from_utf8(bytes.as_slice())?.to_string();
-        return Err(Error::msg(msg));
-    };
-
-    let bytes_written = *body_written_ptr as usize;
-    let headers_written = *headers_written_ptr as usize;
-
-    // Return the body, headers, and status code.
-    Ok((
-        Vec::from_raw_parts(*body_res_ptr as *mut u8, bytes_written, bytes_written),
-        Vec::from_raw_parts(
-            *headers_res_ptr as *mut u8,
-            headers_written,
-            headers_written,
-        ),
-        *status_code_ptr as u16,
-    ))
-}
-
-/// Import `wasi_experimental_http` from the runtime.
-#[link(wasm_import_module = "wasi_experimental_http")]
-extern "C" {
-    fn req(
-        url_ptr: *const u8,
-        url_len_ptr: usize,
-        method_ptr: *const u8,
-        method_len_ptr: usize,
-        req_body_ptr: *const u8,
-        req_body_len_ptr: usize,
-        headers_ptr: *const u8,
-        headers_len_ptr: usize,
-        body_res_ptr: *const *mut u8,
-        body_written_ptr: *mut usize,
-        headers_res_ptr: *const *mut u8,
-        headers_written_ptr: *mut usize,
-        status_code_ptr: *mut u16,
-        err_ptr: *const *mut u8,
-        err_written_ptr: *mut usize,
-    ) -> u32;
-}
-
-/// Allocate memory into the module's linear memory
-/// and return the offset to the start of the block.
-#[no_mangle]
-pub extern "C" fn alloc(len: usize) -> *mut u8 {
-    let mut buf = Vec::with_capacity(len);
-    let ptr = buf.as_mut_ptr();
-
-    std::mem::forget(buf);
-    ptr
-}
-
-/// Get a raw pointer to a `u32` where the runtime can write the
-/// number of bytes written.
-unsafe fn raw_ptr<T: Default>() -> *mut T {
-    let mut x: Box<T> = Box::new(T::default());
-    let ptr: *mut T = &mut *x;
-    std::mem::forget(x);
-    ptr
-}
-
-unsafe fn raw_string_ptr() -> *mut *mut u8 {
-    let mut x: Box<*mut u8> = Box::new(std::ptr::null_mut());
-    let ptr: *mut *mut u8 = &mut *x;
-    std::mem::forget(x);
-    ptr
+        pub fn body_read(
+            handle: u32,
+            buf_ptr: *mut u8,
+            buf_len: usize,
+            but_read_ptr: *mut usize,
+        ) -> u32;
+    }
 }
 
 #[cfg(test)]
@@ -227,13 +238,5 @@ mod tests {
             "custom-header:custom-value\ncustom-header2:custom-value2\n",
             str
         );
-    }
-
-    #[test]
-    fn test_string_to_header_map() {
-        let headers = "custom-header:custom-value\ncustom-header2:custom-value2\n";
-        let header_map = string_to_header_map(headers).unwrap();
-        assert_eq!("custom-value", header_map.get("custom-header").unwrap());
-        assert_eq!("custom-value2", header_map.get("custom-header2").unwrap());
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # `wasi-experimental-http`
 
 This is an experiment intended to provide a _temporary_ workaround until the
-WASI networking API is stable, and is compatible with [Wasmtime v0.24][24] by
+WASI networking API is stable, and is compatible with [Wasmtime v0.25][24] by
 using the `wasi_experiemental_http_wasmtime` crate. We expect that once [the
 WASI sockets proposal][sockets-wip] gets adopted and implemented in language
 toolchains, the need for this library will vanish.
@@ -42,7 +42,7 @@ update a Wasmtime runtime with the experimental HTTP support.
 ### Adding support to a Wasmtime runtime
 
 The easiest way to add support is by using the
-[Wasmtime linker](https://docs.rs/wasmtime/0.24.0/wasmtime/struct.Linker.html):
+[Wasmtime linker](https://docs.rs/wasmtime/0.25.0/wasmtime/struct.Linker.html):
 
 ```rust
 let store = Store::default();
@@ -89,7 +89,7 @@ have the protocol also specified - i.e. `https://my-domain.com`, or
 be in the allowed list. See the the library tests for more examples).
 
 Note that the Wasmtime version currently supported is
-[0.24](https://docs.rs/wasmtime/0.24.0/wasmtime/).
+[0.25](https://docs.rs/wasmtime/0.25.0/wasmtime/).
 
 ### Sending HTTP requests from AssemblyScript
 
@@ -141,5 +141,5 @@ For more information see the
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any
 additional questions or comments.
 
-[24]: https://github.com/bytecodealliance/wasmtime/releases/tag/v0.24.0
+[24]: https://github.com/bytecodealliance/wasmtime/releases/tag/v0.25.0
 [sockets-wip]: https://github.com/WebAssembly/WASI/pull/312

--- a/readme.md
+++ b/readme.md
@@ -29,10 +29,10 @@ pub extern "C" fn _start() {
     let req = req.body(Some(b)).unwrap();
 
     let res = wasi_experimental_http::request(req).expect("cannot make request");
-    let str = std::str::from_utf8(&res.body()).unwrap().to_string();
-    println!("{:#?}", res.headers());
+    let str = std::str::from_utf8(&res.body_read_all()).unwrap().to_string();
+    println!("{:#?}", res.header_get("Content-Type"));
     println!("{}", str);
-    println!("{:#?}", res.status().to_string());
+    println!("{:#?}", res.status_code);
 }
 ```
 
@@ -128,9 +128,6 @@ export function _start_(): void {
 - there are no WITX definitions, which means we have to manually keep the host
   call and guest implementation in sync. Adding WITX definitions could also
   enable support for other WASI runtimes.
-- the `alloc` function in AssemblyScript has to be re-exported in order for the
-  runtime to use it. There probably is a decorator or Binaryen setting to avoid
-  removing it, but for now this has to be re-exported.
 - this library does not aim to add support for running HTTP servers in
   WebAssembly.
 

--- a/tests/as/package-lock.json
+++ b/tests/as/package-lock.json
@@ -1,6 +1,50 @@
 {
+  "name": "as",
+  "lockfileVersion": 2,
   "requires": true,
-  "lockfileVersion": 1,
+  "packages": {
+    "": {
+      "dependencies": {
+        "as-wasi": "0.4.4",
+        "assemblyscript": "^0.18.16"
+      }
+    },
+    "node_modules/as-wasi": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/as-wasi/-/as-wasi-0.4.4.tgz",
+      "integrity": "sha512-CNeZ3AjKSjrFXRNDRzX1VzxsWz3Fwksn4g0J7tZv5RKz4agKhVlcl0QeMIOOkJms7DujCBCpbelGxNDtvlFKmw=="
+    },
+    "node_modules/assemblyscript": {
+      "version": "0.18.18",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.18.18.tgz",
+      "integrity": "sha512-X8tcvrckuR8L8e2e85rxiBjvl1OXFx6KbHiHbC0eEHhr8R1DMBMdJbnoWRf50HU8UDqps6M+8tLXsannTI999w==",
+      "dependencies": {
+        "binaryen": "100.0.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "asc": "bin/asc",
+        "asinit": "bin/asinit"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/assemblyscript"
+      }
+    },
+    "node_modules/binaryen": {
+      "version": "100.0.0",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-100.0.0.tgz",
+      "integrity": "sha512-nxOt8d8/VXAuSVEtAWUdKrqpqCy365QqD223EzzB1GzS5himiZAfM/R5lXx+M/5q8TB8cYp3tYxv5rTjNTJveQ==",
+      "bin": {
+        "wasm-opt": "bin/wasm-opt"
+      }
+    },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    }
+  },
   "dependencies": {
     "as-wasi": {
       "version": "0.4.4",
@@ -8,9 +52,9 @@
       "integrity": "sha512-CNeZ3AjKSjrFXRNDRzX1VzxsWz3Fwksn4g0J7tZv5RKz4agKhVlcl0QeMIOOkJms7DujCBCpbelGxNDtvlFKmw=="
     },
     "assemblyscript": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.18.15.tgz",
-      "integrity": "sha512-s1N1qwdBhen2SLQApYCtRIPWm1Am3oAbW58GCEKbeN6ZbQRh7nq0pv4RDqKw6CgK7dySn/F2S1D6p0scyRbQRw==",
+      "version": "0.18.18",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.18.18.tgz",
+      "integrity": "sha512-X8tcvrckuR8L8e2e85rxiBjvl1OXFx6KbHiHbC0eEHhr8R1DMBMdJbnoWRf50HU8UDqps6M+8tLXsannTI999w==",
       "requires": {
         "binaryen": "100.0.0",
         "long": "^4.0.0"

--- a/tests/as/package.json
+++ b/tests/as/package.json
@@ -4,6 +4,6 @@
   },
   "dependencies": {
     "as-wasi": "0.4.4",
-    "assemblyscript": "^0.18.12"
+    "assemblyscript": "^0.18.16"
   }
 }

--- a/tests/rust/src/lib.rs
+++ b/tests/rust/src/lib.rs
@@ -4,12 +4,13 @@ use bytes::Bytes;
 pub extern "C" fn get() {
     let url = "https://api.brigade.sh/healthz".to_string();
     let req = http::request::Builder::new().uri(&url).body(None).unwrap();
-    let res = wasi_experimental_http::request(req).expect("cannot make get request");
-
-    let str = std::str::from_utf8(&res.body()).unwrap().to_string();
+    let mut res = wasi_experimental_http::request(req).expect("cannot make get request");
+    let str = std::str::from_utf8(&res.body_read_all().unwrap())
+        .unwrap()
+        .to_string();
     assert_eq!(str, r#""OK""#);
-    assert_eq!(res.status(), 200);
-    assert_eq!(res.headers().len(), 6);
+    assert_eq!(res.status_code, 200);
+    assert!(!res.header_get("content-type").unwrap().is_empty());
 }
 
 #[no_mangle]
@@ -23,8 +24,10 @@ pub extern "C" fn post() {
     let b = Bytes::from("Testing with a request body. Does this actually work?");
     let req = req.body(Some(b)).unwrap();
 
-    let res = wasi_experimental_http::request(req).expect("cannot make post request");
-    let _ = std::str::from_utf8(&res.body()).unwrap().to_string();
-    assert_eq!(res.status(), 200);
-    assert_eq!(res.headers().len(), 7);
+    let mut res = wasi_experimental_http::request(req).expect("cannot make post request");
+    let _ = std::str::from_utf8(&res.body_read_all().unwrap())
+        .unwrap()
+        .to_string();
+    assert_eq!(res.status_code, 200);
+    assert!(!res.header_get("content-type").unwrap().is_empty());
 }


### PR DESCRIPTION
Hi!

This is a proposal to support streaming (at least in the API and for responses), avoid the `alloc` function, and simplify the current implementation while making it closer to other WASI proposals.

`req()` now returns a handle to a `Response` object, along with the status code.

A `Response` object can be then used to:
- Read individual headers
- Read the body in a streaming fashion.

A `body_read()` function pulls as many bytes as the client wants, and returns `0` when the end of the stream is reached.
This makes it compatible with streaming, doesn't require any dynamic memory allocation, and allows the client to control the maximum response size it's willing to accept.

For conveniency, the Rust and AssemblyScript bindings also have a `readAll` function that reads everything until the end and puts that into a dynamically allocated array.

Usage in an app using wasmtime is now similar to wasi (core) and other WASI proposals, with an object and an `add_to_linker()` function.

Errors are a little bit easier to keep track of, by using Rust errors, that are converted to return codes when needed. WITX is supposed to provide eventually provide the magic to get error strings from that.

Dependencies have been updated, especially `wasmtime`.