### PR TITLE
Add comments to Rust implementation

### DIFF
--- a/crates/as/index.ts
+++ b/crates/as/index.ts
@@ -16,7 +16,7 @@ export class Response {
     public status: StatusCode;
 
     /** The response handle */
-    public handle: u32;
+    handle: u32;
 
     constructor(status: u16, handle: u32) {
         this.status = status;
@@ -64,7 +64,6 @@ export class Response {
 
     public close(): void {
         close(this.handle);
-
     }
 }
 
@@ -223,7 +222,7 @@ function raw_request(
         // Based on the error code, read and log the error.
         Console.log("ERROR CODE: " + err.toString());
 
-        // An error code was written. Read it, then abort.       
+        // An error code was written. Read it, then abort.
         Console.log("Runtime error: " + err.toString());
         abort();
     }

--- a/tests/as/package-lock.json
+++ b/tests/as/package-lock.json
@@ -1,50 +1,6 @@
 {
-  "name": "as",
-  "lockfileVersion": 2,
   "requires": true,
-  "packages": {
-    "": {
-      "dependencies": {
-        "as-wasi": "0.4.4",
-        "assemblyscript": "^0.18.16"
-      }
-    },
-    "node_modules/as-wasi": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/as-wasi/-/as-wasi-0.4.4.tgz",
-      "integrity": "sha512-CNeZ3AjKSjrFXRNDRzX1VzxsWz3Fwksn4g0J7tZv5RKz4agKhVlcl0QeMIOOkJms7DujCBCpbelGxNDtvlFKmw=="
-    },
-    "node_modules/assemblyscript": {
-      "version": "0.18.18",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.18.18.tgz",
-      "integrity": "sha512-X8tcvrckuR8L8e2e85rxiBjvl1OXFx6KbHiHbC0eEHhr8R1DMBMdJbnoWRf50HU8UDqps6M+8tLXsannTI999w==",
-      "dependencies": {
-        "binaryen": "100.0.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "asc": "bin/asc",
-        "asinit": "bin/asinit"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/assemblyscript"
-      }
-    },
-    "node_modules/binaryen": {
-      "version": "100.0.0",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-100.0.0.tgz",
-      "integrity": "sha512-nxOt8d8/VXAuSVEtAWUdKrqpqCy365QqD223EzzB1GzS5himiZAfM/R5lXx+M/5q8TB8cYp3tYxv5rTjNTJveQ==",
-      "bin": {
-        "wasm-opt": "bin/wasm-opt"
-      }
-    },
-    "node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    }
-  },
+  "lockfileVersion": 1,
   "dependencies": {
     "as-wasi": {
       "version": "0.4.4",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,7 +3,7 @@ mod tests {
     use anyhow::Error;
     use std::time::Instant;
     use wasi_cap_std_sync::WasiCtxBuilder;
-    use wasi_experimental_http_wasmtime::Http;
+    use wasi_experimental_http_wasmtime::HttpCtx;
     use wasmtime::*;
     use wasmtime_wasi::Wasi;
 
@@ -94,7 +94,7 @@ mod tests {
         let wasi = Wasi::new(&store, ctx);
         wasi.add_to_linker(&mut linker)?;
         // Link `wasi_experimental_http`
-        let http = Http::new(allowed_domains)?;
+        let http = HttpCtx::new(allowed_domains)?;
         http.add_to_linker(&mut linker)?;
 
         let module = wasmtime::Module::from_file(store.engine(), filename)?;


### PR DESCRIPTION
This commit updates the Rust Wasmtime and guest implementations with
some more detailed comments, and slightly refactors and renames a few
structs, particularly `Http` -> `HttpCtx`.