### PR TITLE
Add option to limit maximum concurrent requests

### DIFF
--- a/crates/wasi-experimental-http/src/lib.rs
+++ b/crates/wasi-experimental-http/src/lib.rs
@@ -17,7 +17,7 @@ pub enum HttpError {
     #[error("Header not found")]
     HeaderNotFound,
     #[error("UTF-8 error")]
-    UTF8Error,
+    Utf8Error,
     #[error("Destination not allowed")]
     DestinationNotAllowed,
     #[error("Invalid method")]
@@ -42,7 +42,7 @@ fn raw_err_check(e: u32) -> Result<(), HttpError> {
         3 => Err(HttpError::MemoryAccessError),
         4 => Err(HttpError::BufferTooSmall),
         5 => Err(HttpError::HeaderNotFound),
-        6 => Err(HttpError::UTF8Error),
+        6 => Err(HttpError::Utf8Error),
         7 => Err(HttpError::DestinationNotAllowed),
         8 => Err(HttpError::InvalidMethod),
         9 => Err(HttpError::InvalidEncoding),

--- a/tests/as/index.ts
+++ b/tests/as/index.ts
@@ -28,6 +28,18 @@ export function get(): void {
   res.close();
 }
 
+export function concurrent(): void {
+  let req1 = makeReq();
+  let req2 = makeReq();
+  let req3 = makeReq();
+}
+
+function makeReq(): Response {
+  return new RequestBuilder("https://api.brigade.sh/healthz")
+    .method(Method.GET)
+    .send();
+}
+
 function check(
   res: Response,
   expectedStatus: u32,
@@ -36,9 +48,9 @@ function check(
   if (res.status != expectedStatus) {
     Console.write(
       "expected status " +
-      expectedStatus.toString() +
-      " got " +
-      res.status.toString()
+        expectedStatus.toString() +
+        " got " +
+        res.status.toString()
     );
     abort();
   }

--- a/tests/rust/src/lib.rs
+++ b/tests/rust/src/lib.rs
@@ -31,3 +31,18 @@ pub extern "C" fn post() {
     assert_eq!(res.status_code, 200);
     assert!(!res.header_get("content-type").unwrap().is_empty());
 }
+
+#[allow(unused_variables)]
+#[no_mangle]
+pub extern "C" fn concurrent() {
+    let url = "https://api.brigade.sh/healthz".to_string();
+    // the responses are unused to avoid dropping them.
+    let req1 = make_req(url.clone());
+    let req2 = make_req(url.clone());
+    let req3 = make_req(url);
+}
+
+fn make_req(url: String) -> wasi_experimental_http::Response {
+    let req = http::request::Builder::new().uri(&url).body(None).unwrap();
+    wasi_experimental_http::request(req).expect("cannot make get request")
+}


### PR DESCRIPTION
This commit adds a runtime option to limit the maximum number of
concurrent requests a guest module can make.
If set, the runtime implementation checks the current number of open
handles and if it exceeds the limit, the current request will fail.

Note that this does not affect the default (set as `None`), in which
case guests can send as many requests as they want.

This affects the "un-closed" handles - for example, if a Rust `Response`
goes out of scope, `Drop` will be automatically executed and the handle
closed, so the request does not count towards the limit.
On the other hand, the current AssemblyScript implementation requires
the guest to manually close the handle, so this could have an impact.
A subsequent change to the AssemblyScript implementation should
implement a GC finalizer for `Response`.

closes #46 