### PR TITLE
Add `headers_get_all` hostcall and client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 build/
 node_modules/
 package-lock.json
+build

--- a/build.rs
+++ b/build.rs
@@ -14,6 +14,7 @@ fn main() {
     println!("cargo:rerun-if-changed=crates/wasi-experimental-http/src/lib.rs");
     println!("cargo:rerun-if-changed=tests/as/index.ts");
     println!("cargo:rerun-if-changed=crates/as/index.ts");
+    println!("cargo:rerun-if-changed=witx/wasi_experimental_http.witx");
 
     generate_from_witx("rust".to_string(), RUST_GUEST_RAW.to_string());
     generate_from_witx("assemblyscript".to_string(), AS_GUEST_RAW.to_string());

--- a/crates/as/index.ts
+++ b/crates/as/index.ts
@@ -29,6 +29,7 @@ export class Response {
     this.handle = handle;
   }
 
+  /** Read a part of the response body in a supplied buffer */
   public bodyRead(buffer: ArrayBuffer): usize {
     let buf_read_ptr = memory.data(8);
     if (
@@ -44,6 +45,7 @@ export class Response {
     return load<isize>(buf_read_ptr);
   }
 
+  /** Read the entire response body */
   public bodyReadAll(): Uint8Array {
     let chunk = new Uint8Array(4096);
     let buf = new Array<u8>();
@@ -58,6 +60,7 @@ export class Response {
     }
   }
 
+  /** Get a single header value given its key */
   public headerGet(name: string): string {
     let name_buf = String.UTF8.encode(name);
     let name_ptr = changetype<usize>(name_buf);
@@ -83,6 +86,20 @@ export class Response {
 
     let value = value_buf.subarray(0, load<u32>(value_len_ptr));
     return String.UTF8.decode(value.buffer);
+  }
+
+  /** Read all response headers into a header map */
+  public headerGetAll(): Map<string, string> {
+    let headers_buf = new Uint8Array(4*1024);
+    let headers_buf_ptr = changetype<usize>(headers_buf.buffer);
+    let headers_len_ptr = memory.data(8);
+
+    if (raw.headerGetAll(this.handle, headers_buf_ptr, headers_buf.byteLength, headers_len_ptr) != 0) {
+      return new Map<string, string>();
+    }
+
+    let headers = String.UTF8.decode(headers_buf.subarray(0, load<u32>(headers_len_ptr)).buffer);
+    return stringToHeaderMap(headers);
   }
 
   public close(): void {
@@ -209,6 +226,19 @@ function headersToString(headers: Map<string, string>): string {
   for (let index = 0, len = keys.length; index < len; ++index) {
     res += keys[index] + ":" + values[index] + "\n";
   }
+  return res;
+}
+
+/** Transform the string representation of the headers into a map. */
+function stringToHeaderMap(headersStr: string): Map<string, string> {
+  let res = new Map<string, string>();
+  let parts = headersStr.split("\n");
+  // the result of the split contains an empty part as well
+  for (let index = 0, len = parts.length - 1; index < len; index++) {
+      let p = parts[index].split(":");
+      res.set(p[0], p[1]);
+  }
+
   return res;
 }
 

--- a/crates/as/index.ts
+++ b/crates/as/index.ts
@@ -90,15 +90,24 @@ export class Response {
 
   /** Read all response headers into a header map */
   public headerGetAll(): Map<string, string> {
-    let headers_buf = new Uint8Array(4*1024);
+    let headers_buf = new Uint8Array(4 * 1024);
     let headers_buf_ptr = changetype<usize>(headers_buf.buffer);
     let headers_len_ptr = memory.data(8);
 
-    if (raw.headerGetAll(this.handle, headers_buf_ptr, headers_buf.byteLength, headers_len_ptr) != 0) {
+    if (
+      raw.headersGetAll(
+        this.handle,
+        headers_buf_ptr,
+        headers_buf.byteLength,
+        headers_len_ptr
+      ) != 0
+    ) {
       return new Map<string, string>();
     }
 
-    let headers = String.UTF8.decode(headers_buf.subarray(0, load<u32>(headers_len_ptr)).buffer);
+    let headers = String.UTF8.decode(
+      headers_buf.subarray(0, load<u32>(headers_len_ptr)).buffer
+    );
     return stringToHeaderMap(headers);
   }
 
@@ -235,8 +244,8 @@ function stringToHeaderMap(headersStr: string): Map<string, string> {
   let parts = headersStr.split("\n");
   // the result of the split contains an empty part as well
   for (let index = 0, len = parts.length - 1; index < len; index++) {
-      let p = parts[index].split(":");
-      res.set(p[0], p[1]);
+    let p = parts[index].split(":");
+    res.set(p[0], p[1]);
   }
 
   return res;

--- a/crates/as/raw.ts
+++ b/crates/as/raw.ts
@@ -147,6 +147,15 @@ export declare function headerGet(
     result_ptr: WasiMutPtr<WrittenBytes>
 ): HttpError;
 
+// @ts-ignore: decorator
+@external("wasi_experimental_http", "header_get_all")
+export declare function headerGetAll(
+    response_handle: ResponseHandle,
+    header_value_buf_ptr: WasiMutPtr<u8>,
+    header_value_buf_len: usize,
+    result_ptr: WasiMutPtr<WrittenBytes>
+): HttpError;
+
 /**
  * Fill a buffer with the streamed content of a response body
  */

--- a/crates/as/raw.ts
+++ b/crates/as/raw.ts
@@ -151,8 +151,8 @@ export declare function headerGet(
  * Get the entire response header map
  */
 // @ts-ignore: decorator
-@external("wasi_experimental_http", "header_get_all")
-export declare function headerGetAll(
+@external("wasi_experimental_http", "headers_get_all")
+export declare function headersGetAll(
     response_handle: ResponseHandle,
     header_value_buf_ptr: WasiMutPtr<u8>,
     header_value_buf_len: usize,

--- a/crates/as/raw.ts
+++ b/crates/as/raw.ts
@@ -147,6 +147,9 @@ export declare function headerGet(
     result_ptr: WasiMutPtr<WrittenBytes>
 ): HttpError;
 
+/**
+ * Get the entire response header map
+ */
 // @ts-ignore: decorator
 @external("wasi_experimental_http", "header_get_all")
 export declare function headerGetAll(

--- a/crates/as/readme.md
+++ b/crates/as/readme.md
@@ -47,12 +47,6 @@ module can be executed in a Wasmtime runtime that has the experimental HTTP
 functionality enabled (the crate to configure it can be found in this repo):
 
 ```
-wasi_experimental_http::data_from_memory:: length: 29
-wasi_experimental_http::data_from_memory:: length: 41
-wasi_experimental_http::data_from_memory:: length: 4
-wasi_experimental_http::data_from_memory:: length: 53
-wasi_experimental_http::write_guest_memory:: written 336 bytes
-wasi_experimental_http::write_guest_memory:: written 374 bytes
 {
     "content-length": "374",
     "connection": "keep-alive",

--- a/crates/wasi-experimental-http-wasmtime/readme.md
+++ b/crates/wasi-experimental-http-wasmtime/readme.md
@@ -18,7 +18,10 @@ let wasi = Wasi::new(&store, ctx);
 wasi.add_to_linker(&mut linker)?;
 
 // link the experimental HTTP support
-let http = Http::new(None);
+let allowed_hosts = Some(vec!["https://postman-echo.com".to_string()]);
+let max_concurrent_requests = Some(42);
+
+let http = HttpCtx::new(allowed_domains, max_concurrent_requests)?;
 http.add_to_linker(&mut linker)?;
 ```
 

--- a/crates/wasi-experimental-http-wasmtime/src/lib.rs
+++ b/crates/wasi-experimental-http-wasmtime/src/lib.rs
@@ -530,7 +530,6 @@ fn string_from_memory(memory: &Memory, offset: u32, len: u32) -> Result<&str, Ht
 /// allowed hosts defined by the runtime.
 /// If `None` is passed, the guest module is not allowed to send the request.
 fn is_allowed(url: &str, allowed_hosts: Option<&[String]>) -> Result<bool, HttpError> {
-    // println!("trying to access url {}", url);
     let url_host = Url::parse(url)
         .map_err(|_| HttpError::InvalidUrl)?
         .host_str()

--- a/crates/wasi-experimental-http-wasmtime/src/lib.rs
+++ b/crates/wasi-experimental-http-wasmtime/src/lib.rs
@@ -162,7 +162,7 @@ impl HostCalls {
         Ok(())
     }
 
-    fn header_get_all(
+    fn headers_get_all(
         st: Rc<RefCell<State>>,
         caller: Caller<'_>,
         handle: WasiHttpHandle,
@@ -171,7 +171,6 @@ impl HostCalls {
         buf_written_ptr: u32,
     ) -> Result<(), HttpError> {
         let mut st = st.borrow_mut();
-        // Get the current response body.
         let headers = &mut st
             .responses
             .get_mut(&handle)
@@ -376,14 +375,14 @@ impl HttpCtx {
         let st = self.state.clone();
         linker.func(
             Self::MODULE,
-            "header_get_all",
+            "headers_get_all",
             move |caller: Caller<'_>,
                   handle: WasiHttpHandle,
                   buf_ptr: u32,
                   buf_len: u32,
                   buf_read_ptr: u32|
                   -> u32 {
-                match HostCalls::header_get_all(
+                match HostCalls::headers_get_all(
                     st.clone(),
                     caller,
                     handle,

--- a/crates/wasi-experimental-http/readme.md
+++ b/crates/wasi-experimental-http/readme.md
@@ -26,10 +26,10 @@ pub extern "C" fn _start() {
     let req = req.body(Some(b)).unwrap();
 
     let res = wasi_experimental_http::request(req).expect("cannot make request");
-    let str = std::str::from_utf8(&res.body()).unwrap().to_string();
-    println!("{:#?}", res.headers());
+    let str = std::str::from_utf8(&res.body_read_all()).unwrap().to_string();
+    println!("{:#?}", res.header_get("Content-Type"));
     println!("{}", str);
-    println!("{:#?}", res.status().to_string());
+    println!("{:#?}", res.status_code);
 }
 ```
 
@@ -38,12 +38,6 @@ runtime that has the experimental HTTP functionality enabled (the crate to
 configure it can be found in this repo):
 
 ```
-wasi_experimental_http::data_from_memory:: length: 29
-wasi_experimental_http::data_from_memory:: length: 41
-wasi_experimental_http::data_from_memory:: length: 4
-wasi_experimental_http::data_from_memory:: length: 53
-wasi_experimental_http::write_guest_memory:: written 336 bytes
-wasi_experimental_http::write_guest_memory:: written 374 bytes
 {
     "content-length": "374",
     "connection": "keep-alive",

--- a/crates/wasi-experimental-http/src/lib.rs
+++ b/crates/wasi-experimental-http/src/lib.rs
@@ -171,13 +171,13 @@ impl Response {
         let capacity = 64 * 1024;
         let mut buf = vec![0u8; capacity];
 
-        match raw::header_get_all(self.handle, buf.as_mut_ptr(), buf.len()) {
+        match raw::headers_get_all(self.handle, buf.as_mut_ptr(), buf.len()) {
             Ok(written) => {
                 buf.truncate(written);
                 let str = String::from_utf8(buf)?;
                 return Ok(string_to_header_map(&str)?);
             }
-            Err(e) => panic!("error: {:#?}", e),
+            Err(e) => return Err(e.into()),
         };
     }
 }

--- a/crates/wasi-experimental-http/src/lib.rs
+++ b/crates/wasi-experimental-http/src/lib.rs
@@ -152,6 +152,20 @@ impl Response {
             };
         }
     }
+
+    pub fn headers_get_all(&self) -> Result<HeaderMap, Error> {
+        let capacity = 64 * 1024;
+        let mut buf = vec![0u8; capacity];
+
+        match raw::header_get_all(self.handle, buf.as_mut_ptr(), buf.len()) {
+            Ok(written) => {
+                buf.truncate(written);
+                let str = String::from_utf8(buf)?;
+                return Ok(string_to_header_map(&str)?);
+            }
+            Err(e) => panic!("error: {:#?}", e),
+        };
+    }
 }
 
 /// Send an HTTP request.

--- a/crates/wasi-experimental-http/src/lib.rs
+++ b/crates/wasi-experimental-http/src/lib.rs
@@ -153,7 +153,21 @@ impl Response {
         }
     }
 
+    /// Get the entire response header map for a given request.
+    // If clients know the specific header key, they should use
+    // `header_get` to avoid allocating memory for the entire
+    // header map.
     pub fn headers_get_all(&self) -> Result<HeaderMap, Error> {
+        // The fixed capacity for the header map is 64 kilobytes.
+        // If a server sends a header map that is larger than this,
+        // the client will return an error.
+        // The same note applies - most known servers will limit
+        // response headers to 64 kilobytes at most before returning
+        // 413 Entity Too Large.
+        //
+        // It might make sense to increase the size here in the same
+        // way it is done in `header_get`, if there are valid use
+        // cases where it is required.
         let capacity = 64 * 1024;
         let mut buf = vec![0u8; capacity];
 

--- a/crates/wasi-experimental-http/src/raw.rs
+++ b/crates/wasi-experimental-http/src/raw.rs
@@ -248,6 +248,7 @@ pub fn header_get(
     Ok(unsafe { result_ptr.assume_init() })
 }
 
+/// Get the entire response header map
 pub fn header_get_all(
     response_handle: ResponseHandle,
     header_value_buf_ptr: WasiMutPtr<u8>,

--- a/crates/wasi-experimental-http/src/raw.rs
+++ b/crates/wasi-experimental-http/src/raw.rs
@@ -249,14 +249,14 @@ pub fn header_get(
 }
 
 /// Get the entire response header map
-pub fn header_get_all(
+pub fn headers_get_all(
     response_handle: ResponseHandle,
     header_value_buf_ptr: WasiMutPtr<u8>,
     header_value_buf_len: usize,
 ) -> Result<WrittenBytes, Error> {
     #[link(wasm_import_module = "wasi_experimental_http")]
     extern "C" {
-        fn header_get_all(
+        fn headers_get_all(
             response_handle: ResponseHandle,
             header_value_buf_ptr: WasiMutPtr<u8>,
             header_value_buf_len: usize,
@@ -264,7 +264,7 @@ pub fn header_get_all(
         ) -> HttpError;
     }
     let mut result_ptr = std::mem::MaybeUninit::uninit();
-    let res = unsafe { header_get_all(
+    let res = unsafe { headers_get_all(
         response_handle,
         header_value_buf_ptr,
         header_value_buf_len,

--- a/crates/wasi-experimental-http/src/raw.rs
+++ b/crates/wasi-experimental-http/src/raw.rs
@@ -248,6 +248,33 @@ pub fn header_get(
     Ok(unsafe { result_ptr.assume_init() })
 }
 
+pub fn header_get_all(
+    response_handle: ResponseHandle,
+    header_value_buf_ptr: WasiMutPtr<u8>,
+    header_value_buf_len: usize,
+) -> Result<WrittenBytes, Error> {
+    #[link(wasm_import_module = "wasi_experimental_http")]
+    extern "C" {
+        fn header_get_all(
+            response_handle: ResponseHandle,
+            header_value_buf_ptr: WasiMutPtr<u8>,
+            header_value_buf_len: usize,
+            result_ptr: WasiMutPtr<WrittenBytes>,
+        ) -> HttpError;
+    }
+    let mut result_ptr = std::mem::MaybeUninit::uninit();
+    let res = unsafe { header_get_all(
+        response_handle,
+        header_value_buf_ptr,
+        header_value_buf_len,
+        result_ptr.as_mut_ptr(),
+    )};
+    if res != 0 {
+        return Err(Error::WasiError(res as _));
+    }
+    Ok(unsafe { result_ptr.assume_init() })
+}
+
 /// Fill a buffer with the streamed content of a response body
 pub fn body_read(
     response_handle: ResponseHandle,

--- a/tests/as/index.ts
+++ b/tests/as/index.ts
@@ -59,4 +59,9 @@ function check(
   if (!headerValue) {
     abort();
   }
+
+  let headers = res.headerGetAll();
+  if(headers.size == 0) {
+    abort();
+  }
 }

--- a/tests/rust/src/lib.rs
+++ b/tests/rust/src/lib.rs
@@ -14,6 +14,9 @@ pub extern "C" fn get() {
         .header_get("content-type".to_string())
         .unwrap()
         .is_empty());
+
+    let header_map = res.headers_get_all().unwrap();
+    assert_ne!(header_map.len(), 0);
 }
 
 #[no_mangle]
@@ -36,6 +39,9 @@ pub extern "C" fn post() {
         .header_get("content-type".to_string())
         .unwrap()
         .is_empty());
+
+    let header_map = res.headers_get_all().unwrap();
+    assert_ne!(header_map.len(), 0);
 }
 
 #[allow(unused_variables)]

--- a/witx/readme.md
+++ b/witx/readme.md
@@ -154,6 +154,9 @@ Returned error type: _[`http_error`](#http_error)_
 
 * _[`written_bytes`](#written_bytes)_ mutable pointer
 
+> Get the entire response header map
+
+
 ---
 
 ### [`body_read()`](#body_read)

--- a/witx/readme.md
+++ b/witx/readme.md
@@ -9,7 +9,7 @@
 
 ### Functions list:
 
-\[**[All](#functions)**\] - \[[`req()`](#req)\] - \[[`close()`](#close)\] - \[[`header_get()`](#header_get)\] - \[[`body_read()`](#body_read)\]
+\[**[All](#functions)**\] - \[[`req()`](#req)\] - \[[`close()`](#close)\] - \[[`header_get()`](#header_get)\] - \[[`header_get_all()`](#header_get_all)\] - \[[`body_read()`](#body_read)\]
 
 ## Types
 
@@ -139,6 +139,20 @@ Returned error type: _[`http_error`](#http_error)_
 
 > Get the value associated with a header
 
+
+---
+
+### [`header_get_all()`](#header_get_all)
+Returned error type: _[`http_error`](#http_error)_
+
+#### Input:
+
+* **`response_handle`**: _[`response_handle`](#response_handle)_
+* **`header_value_buf`**: _[`header_value_buf`](#header_value_buf)_
+
+#### Output:
+
+* _[`written_bytes`](#written_bytes)_ mutable pointer
 
 ---
 

--- a/witx/readme.md
+++ b/witx/readme.md
@@ -9,7 +9,7 @@
 
 ### Functions list:
 
-\[**[All](#functions)**\] - \[[`req()`](#req)\] - \[[`close()`](#close)\] - \[[`header_get()`](#header_get)\] - \[[`header_get_all()`](#header_get_all)\] - \[[`body_read()`](#body_read)\]
+\[**[All](#functions)**\] - \[[`req()`](#req)\] - \[[`close()`](#close)\] - \[[`header_get()`](#header_get)\] - \[[`headers_get_all()`](#headers_get_all)\] - \[[`body_read()`](#body_read)\]
 
 ## Types
 
@@ -142,7 +142,7 @@ Returned error type: _[`http_error`](#http_error)_
 
 ---
 
-### [`header_get_all()`](#header_get_all)
+### [`headers_get_all()`](#headers_get_all)
 Returned error type: _[`http_error`](#http_error)_
 
 #### Input:

--- a/witx/wasi_experimental_http.witx
+++ b/witx/wasi_experimental_http.witx
@@ -77,6 +77,12 @@
         (result $error (expected $written_bytes (error $http_error)))
     )
 
+    (@interface func (export "header_get_all")
+        (param $response_handle $response_handle)
+        (param $header_value_buf $header_value_buf)
+        (result $error (expected $written_bytes (error $http_error)))
+    )
+
 ;;; Fill a buffer with the streamed content of a response body
     (@interface func (export "body_read")
         (param $response_handle $response_handle)

--- a/witx/wasi_experimental_http.witx
+++ b/witx/wasi_experimental_http.witx
@@ -78,7 +78,7 @@
     )
 
 ;;; Get the entire response header map
-    (@interface func (export "header_get_all")
+    (@interface func (export "headers_get_all")
         (param $response_handle $response_handle)
         (param $header_value_buf $header_value_buf)
         (result $error (expected $written_bytes (error $http_error)))

--- a/witx/wasi_experimental_http.witx
+++ b/witx/wasi_experimental_http.witx
@@ -77,6 +77,7 @@
         (result $error (expected $written_bytes (error $http_error)))
     )
 
+;;; Get the entire response header map
     (@interface func (export "header_get_all")
         (param $response_handle $response_handle)
         (param $header_value_buf $header_value_buf)


### PR DESCRIPTION
closes #55 

This commit adds a new hostcall in the library, together with client
implementation for getting the entire response header map for a given
request.

TODO: 
- [x] add AssemblyScript implementation
- [x] add comments in clients
- [x] add tests in Rust and AssemblyScript