### PR TITLE
Remove client dep to fix Windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
@@ -21,4 +22,15 @@ jobs:
     - name: Build
       run: rustup target add wasm32-wasi && cargo build --verbose
     - name: Run simple test
-      run: cargo test --all -- --nocapture
+      # run: cargo test -- --nocapture
+      run:   |
+            if [ "$RUNNER_OS" == "Windows" ]; then
+                  # Attempting to run the unit tests on Windows
+                  # results in the linker failing because it cannot
+                  # compile the Rust client library because of the
+                  # missing external symbols, so we are only running
+                  # the integration tests on Windows.
+                  cargo test -- --nocapture
+            else
+                  cargo test --all -- --nocapture1
+            fi

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,12 +11,14 @@ env:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: rustup target add wasm32-wasi && cargo install witx-codegen && cargo build --verbose
+      run: rustup target add wasm32-wasi && cargo build --verbose
     - name: Run simple test
       run: cargo test --all -- --nocapture

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Build
       run: rustup target add wasm32-wasi && cargo build --verbose
     - name: Run simple test
-      # run: cargo test -- --nocapture
+      shell: bash
       run:   |
             if [ "$RUNNER_OS" == "Windows" ]; then
                   # Attempting to run the unit tests on Windows
@@ -32,5 +32,5 @@ jobs:
                   # the integration tests on Windows.
                   cargo test -- --nocapture
             else
-                  cargo test --all -- --nocapture1
+                  cargo test --all -- --nocapture
             fi

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 node_modules/
 package-lock.json
 build
+*.exe
+*.pdb

--- a/build.rs
+++ b/build.rs
@@ -79,7 +79,7 @@ fn generate_from_witx(codegen_type: &str, output: &str) {
     );
 }
 
-fn run<S: Into<String> + std::convert::AsRef<std::ffi::OsStr>>(args: Vec<S>, dir: Option<String>) {
+fn run<S: Into<String> + AsRef<std::ffi::OsStr>>(args: Vec<S>, dir: Option<String>) {
     let mut cmd = Command::new(get_os_process());
     cmd.stdout(process::Stdio::piped());
     cmd.stderr(process::Stdio::piped());

--- a/crates/wasi-experimental-http-wasmtime/Cargo.toml
+++ b/crates/wasi-experimental-http-wasmtime/Cargo.toml
@@ -20,5 +20,4 @@ url = "2.2.1"
 wasmtime = "0.26"
 wasmtime-wasi = "0.26"
 wasi-common = "0.26"
-wasi-experimental-http = { version = "0.2", path = "../wasi-experimental-http" }
 tracing = { version = "0.1", features = ["log"] }

--- a/crates/wasi-experimental-http-wasmtime/src/lib.rs
+++ b/crates/wasi-experimental-http-wasmtime/src/lib.rs
@@ -6,7 +6,6 @@ use reqwest::{Client, Method};
 use std::{cell::RefCell, collections::HashMap, rc::Rc, str::FromStr};
 use tokio::runtime::Handle;
 use url::Url;
-// use wasi_experimental_http::header_map_to_string;
 use wasmtime::*;
 
 const MEMORY: &str = "memory";
@@ -554,7 +553,7 @@ fn is_allowed(url: &str, allowed_hosts: Option<&[String]>) -> Result<bool, HttpE
 // https://github.com/rust-lang/rust/issues/86125
 
 /// Decode a header map from a string.
-pub fn string_to_header_map(s: &str) -> Result<HeaderMap, Error> {
+fn string_to_header_map(s: &str) -> Result<HeaderMap, Error> {
     let mut headers = HeaderMap::new();
     for entry in s.lines() {
         let mut parts = entry.splitn(2, ':');
@@ -570,7 +569,7 @@ pub fn string_to_header_map(s: &str) -> Result<HeaderMap, Error> {
 }
 
 /// Encode a header map as a string.
-pub fn header_map_to_string(hm: &HeaderMap) -> Result<String, Error> {
+fn header_map_to_string(hm: &HeaderMap) -> Result<String, Error> {
     let mut res = String::new();
     for (name, value) in hm
         .iter()

--- a/tests/as/index.ts
+++ b/tests/as/index.ts
@@ -21,8 +21,10 @@ export function get(): void {
     .send();
 
   check(res, 200, "content-type");
-  let body = res.bodyReadAll();
-  if (String.UTF8.decode(body.buffer) != '"OK"') {
+  let bytes = res.bodyReadAll();
+  let body = String.UTF8.decode(bytes.buffer);
+  if (!body.includes("OK")) {
+    Console.write("got " + body);
     abort();
   }
   res.close();
@@ -61,7 +63,7 @@ function check(
   }
 
   let headers = res.headerGetAll();
-  if(headers.size == 0) {
+  if (headers.size == 0) {
     abort();
   }
 }


### PR DESCRIPTION
This commit removes the dependency on the client library from the
Wasmtime library in order to fix a Windows linking error.
Specifically, the Windows error stems from the fact that the client
library, which is mainly used for building Wasm modules, imports the
functions related to sending HTTP requests from the runtime.
There seems to be a bug in the Windows linker resulting in a linking
error, even if the Wasmtime crate is not calling any of the external
symbols, and this commit removes that dependency entirely, given that
the used functionality was limited to a single function.
See https://github.com/rust-lang/rust/issues/86125.

This also simplifies `build.rs`, ensuring it should run properly on both
Unix and Windows systems, and updates the GitHub action to compile on
Linux, macOS, and Windows.

close #60 
close #64