### PR TITLE
Update the witx file syntax

### DIFF
--- a/witx/readme.md
+++ b/witx/readme.md
@@ -5,11 +5,11 @@
 
 ### Types list:
 
-\[**[All](#types)**\] - \[_[`http_error`](#http_error)_\] - \[_[`status_code`](#status_code)_\] - \[_[`outgoing_body`](#outgoing_body)_\] - \[_[`incoming_body`](#incoming_body)_\] - \[_[`response_handle`](#response_handle)_\] - \[_[`header_value_buf`](#header_value_buf)_\] - \[_[`written_bytes`](#written_bytes)_\]
+[**[All](#types)**] - [_[`http_error`](#http_error)_] - [_[`status_code`](#status_code)_] - [_[`outgoing_body`](#outgoing_body)_] - [_[`incoming_body`](#incoming_body)_] - [_[`response_handle`](#response_handle)_] - [_[`header_value_buf`](#header_value_buf)_] - [_[`written_bytes`](#written_bytes)_]
 
 ### Functions list:
 
-\[**[All](#functions)**\] - \[[`req()`](#req)\] - \[[`close()`](#close)\] - \[[`header_get()`](#header_get)\] - \[[`headers_get_all()`](#headers_get_all)\] - \[[`body_read()`](#body_read)\]
+[**[All](#functions)**] - [[`req()`](#req)] - [[`close()`](#close)] - [[`header_get()`](#header_get)] - [[`headers_get_all()`](#headers_get_all)] - [[`body_read()`](#body_read)]
 
 ## Types
 

--- a/witx/wasi_experimental_http.witx
+++ b/witx/wasi_experimental_http.witx
@@ -1,60 +1,60 @@
-(typename $http_error
-    (enum (@witx tag u32)
-;;; Success
-        $success
-;;; Invalid handle
-        $invalid_handle
-;;; Memory not found
-        $memory_not_found
-;;; Memory access error
-        $memory_access_error
-;;; Buffer too small
-        $buffer_too_small
-;;; Header not found
-        $header_not_found
-;;; UTF-8 error
-        $utf8_error
-;;; Destination not allowed
-        $destination_not_allowed
-;;; Invalid method
-        $invalid_method
-;;; Invalid encoding
-        $invalid_encoding
-;;; Invalid URL
-        $invalid_url
-;;; Request error
-        $request_error
-;;; Runtime error
-        $runtime_error
-;;; Too many sessions
-        $too_many_sessions
-    )
-)
-
-;;; Handles for the HTTP extensions
-(resource $http_handle)
-
-;;; HTTP status code
-(typename $status_code u16)
-
-;;; An HTTP body being sent
-(typename $outgoing_body (in-buffer u8))
-
-;;; Buffer for an HTTP body being received
-(typename $incoming_body (out-buffer u8))
-
-;;; A response handle
-(typename $response_handle (handle $http_handle))
-
-;;; Buffer to store a header value
-(typename $header_value_buf (out-buffer u8))
-
-;;; Number of bytes having been written
-(typename $written_bytes (@witx usize))
-
 ;;; Experimental HTTP API for WebAssembly
 (module $wasi_experimental_http
-;;; Send a request
+  (typename $http_error
+      (enum (@witx tag u32)
+          ;;; Success
+          $success
+          ;;; Invalid handle
+          $invalid_handle
+          ;;; Memory not found
+          $memory_not_found
+          ;;; Memory access error
+          $memory_access_error
+          ;;; Buffer too small
+          $buffer_too_small
+          ;;; Header not found
+          $header_not_found
+          ;;; UTF-8 error
+          $utf8_error
+          ;;; Destination not allowed
+          $destination_not_allowed
+          ;;; Invalid method
+          $invalid_method
+          ;;; Invalid encoding
+          $invalid_encoding
+          ;;; Invalid URL
+          $invalid_url
+          ;;; Request error
+          $request_error
+          ;;; Runtime error
+          $runtime_error
+          ;;; Too many sessions
+          $too_many_sessions
+      )
+  )
+
+  ;;; Handles for the HTTP extensions
+  (resource $http_handle)
+
+  ;;; HTTP status code
+  (typename $status_code u16)
+
+  ;;; An HTTP body being sent
+  (typename $outgoing_body (in-buffer u8))
+
+  ;;; Buffer for an HTTP body being received
+  (typename $incoming_body (out-buffer u8))
+
+  ;;; A response handle
+  (typename $response_handle (handle $http_handle))
+
+  ;;; Buffer to store a header value
+  (typename $header_value_buf (out-buffer u8))
+
+  ;;; Number of bytes having been written
+  (typename $written_bytes (@witx usize))
+
+  ;;; Send a request
     (@interface func (export "req")
         (param $url string)
         (param $method string)
@@ -63,13 +63,13 @@
         (result $error (expected (tuple $status_code $response_handle) (error $http_error)))
     )
 
-;;; Close a request handle
+    ;;; Close a request handle
     (@interface func (export "close")
         (param $response_handle $response_handle)
         (result $error (expected (error $http_error)))
     )
 
-;;; Get the value associated with a header
+    ;;; Get the value associated with a header
     (@interface func (export "header_get")
         (param $response_handle $response_handle)
         (param $header_name string)
@@ -77,14 +77,14 @@
         (result $error (expected $written_bytes (error $http_error)))
     )
 
-;;; Get the entire response header map
+    ;;; Get the entire response header map
     (@interface func (export "headers_get_all")
         (param $response_handle $response_handle)
         (param $header_value_buf $header_value_buf)
         (result $error (expected $written_bytes (error $http_error)))
     )
 
-;;; Fill a buffer with the streamed content of a response body
+    ;;; Fill a buffer with the streamed content of a response body
     (@interface func (export "body_read")
         (param $response_handle $response_handle)
         (param $body_buf $incoming_body)


### PR DESCRIPTION
The witx syntax was changed to [require types to be included in the module](https://github.com/alexcrichton/WASI/commit/59e67ae8b820b834101b748c1b6efb3f6765f8eb) itself.

`witx-codegen` was updated for the new syntax.

Update our witx file for that change.

The output code remains the same.