### PR TITLE
Add a generic add_to_linker function that accepts generic stores

### DIFF
--- a/crates/wasi-experimental-http/src/lib.rs
+++ b/crates/wasi-experimental-http/src/lib.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 #[allow(dead_code)]
 #[allow(clippy::mut_from_ref)]
-#[allow(clippy::clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 pub(crate) mod raw;
 
 /// HTTP errors
@@ -240,7 +240,7 @@ pub fn string_to_header_map(s: &str) -> Result<HeaderMap, Error> {
     let mut headers = HeaderMap::new();
     for entry in s.lines() {
         let mut parts = entry.splitn(2, ':');
-        #[allow(clippy::clippy::clippy::or_fun_call)]
+        #[allow(clippy::or_fun_call)]
         let k = parts.next().ok_or(anyhow::format_err!(
             "Invalid serialized header: [{}]",
             entry

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -147,7 +147,7 @@ mod tests {
 
         // Link `wasi_experimental_http`
         let http = HttpCtx::new(allowed_domains, max_concurrent_requests)?;
-        http.add_to_linker(&mut linker)?;
+        http.add_to_generic_linker(&mut linker)?;
 
         let module = wasmtime::Module::from_file(store.engine(), filename)?;
 


### PR DESCRIPTION
The previous `add_to_linker` implementation was unusable for any runtime that had a different kind of internal state.
This commit adds a generic function that accepts a `Linker<T>`.

We should probably remove the old function and rename it.

Signed-off-by: Radu M <root@radu.sh>