### PR TITLE
Add a generic `add_to_linker` function that accepts generic stores and update Wasmtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,29 +1,25 @@
 [package]
-name = "wasi-experimental-http-wasmtime-sample"
+name    = "wasi-experimental-http-wasmtime-sample"
 version = "0.5.0"
 authors = ["Radu Matei <radu.matei@microsoft.com>"]
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
-futures = "0.3"
-http = "0.2"
-reqwest = { version = "0.11", default-features = true, features = ["json", "blocking"] }
-structopt = "0.3.21"
-tokio = { version = "1.4.0", features = ["full"] }
-wasmtime = "0.28.0"
-wasmtime-wasi = "0.28.0"
-wasi-common = "0.28.0"
-wasi-cap-std-sync = "0.28.0"
-wasi-experimental-http = { path = "crates/wasi-experimental-http" }
+anyhow                          = "1.0"
+futures                         = "0.3"
+http                            = "0.2"
+reqwest                         = { version = "0.11", default-features = true, features = ["json", "blocking"] }
+structopt                       = "0.3.21"
+tokio                           = { version = "1.4.0", features = ["full"] }
+wasmtime                        = "0.30.0"
+wasmtime-wasi                   = "0.30.0"
+wasi-common                     = "0.30.0"
+wasi-cap-std-sync               = "0.30.0"
+wasi-experimental-http          = { path = "crates/wasi-experimental-http" }
 wasi-experimental-http-wasmtime = { path = "crates/wasi-experimental-http-wasmtime" }
 
 [workspace]
-members = [
-    "crates/wasi-experimental-http",
-    "crates/wasi-experimental-http-wasmtime",
-    "tests/rust"
-]
+members = ["crates/wasi-experimental-http", "crates/wasi-experimental-http-wasmtime", "tests/rust"]
 
 [[bin]]
 name = "wasmtime-http"

--- a/crates/wasi-experimental-http-wasmtime/Cargo.toml
+++ b/crates/wasi-experimental-http-wasmtime/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name = "wasi-experimental-http-wasmtime"
-version = "0.5.0"
-authors = ["Radu Matei <radu.matei@microsoft.com>"]
-edition = "2018"
-repository = "https://github.com/deislabs/wasi-experimental-http"
-license = "MIT"
+name        = "wasi-experimental-http-wasmtime"
+version     = "0.5.0"
+authors     = ["Radu Matei <radu.matei@microsoft.com>"]
+edition     = "2018"
+repository  = "https://github.com/deislabs/wasi-experimental-http"
+license     = "MIT"
 description = "Experimental HTTP library for WebAssembly in Wasmtime"
-readme = "readme.md"
+readme      = "readme.md"
 
 [dependencies]
-anyhow = "1.0"
-bytes = "1"
-futures = "0.3"
-http = "0.2"
-reqwest = { version = "0.11", default-features = true, features = ["json", "blocking"] }
-thiserror = "1.0"
-tokio = { version = "1.4.0", features = ["full"] }
-url = "2.2.1"
-wasmtime = "0.28"
-wasmtime-wasi = "0.28"
-wasi-common = "0.28"
-tracing = { version = "0.1", features = ["log"] }
+anyhow        = "1.0"
+bytes         = "1"
+futures       = "0.3"
+http          = "0.2"
+reqwest       = { version = "0.11", default-features = true, features = ["json", "blocking"] }
+thiserror     = "1.0"
+tokio         = { version = "1.4.0", features = ["full"] }
+tracing       = { version = "0.1", features = ["log"] }
+url           = "2.2.1"
+wasmtime      = "0.30"
+wasmtime-wasi = "0.30"
+wasi-common   = "0.30"

--- a/crates/wasi-experimental-http-wasmtime/src/lib.rs
+++ b/crates/wasi-experimental-http-wasmtime/src/lib.rs
@@ -10,7 +10,6 @@ use std::{
 };
 use tokio::runtime::Handle;
 use url::Url;
-use wasi_common::WasiCtx;
 use wasmtime::*;
 
 const MEMORY: &str = "memory";
@@ -346,7 +345,7 @@ impl HttpCtx {
         })
     }
 
-    pub fn add_to_generic_linker<T>(&self, linker: &mut Linker<T>) -> Result<(), Error> {
+    pub fn add_to_linker<T>(&self, linker: &mut Linker<T>) -> Result<(), Error> {
         let st = self.state.clone();
         linker.func_wrap(
             Self::MODULE,
@@ -508,11 +507,6 @@ impl HttpCtx {
         )?;
 
         Ok(())
-    }
-
-    /// Register the module with the Wasmtime linker.
-    pub fn add_to_linker(&self, linker: &mut Linker<WasiCtx>) -> Result<(), Error> {
-        self.add_to_generic_linker(linker)
     }
 }
 

--- a/crates/wasi-experimental-http/Cargo.toml
+++ b/crates/wasi-experimental-http/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name = "wasi-experimental-http"
-version = "0.5.0"
-authors = ["Radu Matei <radu.matei@microsoft.com>"]
-edition = "2018"
-repository = "https://github.com/deislabs/wasi-experimental-http"
-license = "MIT"
+name        = "wasi-experimental-http"
+version     = "0.5.0"
+authors     = ["Radu Matei <radu.matei@microsoft.com>"]
+edition     = "2018"
+repository  = "https://github.com/deislabs/wasi-experimental-http"
+license     = "MIT"
 description = "Experimental HTTP library for WebAssembly"
-readme = "readme.md"
+readme      = "readme.md"
 
 [dependencies]
-anyhow = "1.0"
-bytes = "1"
-http = "0.2"
+anyhow    = "1.0"
+bytes     = "1"
+http      = "0.2"
 thiserror = "1.0"
-tracing = { version = "0.1", features = ["log"] }
+tracing   = { version = "0.1", features = ["log"] }

--- a/crates/wasi-experimental-http/src/lib.rs
+++ b/crates/wasi-experimental-http/src/lib.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 #[allow(dead_code)]
 #[allow(clippy::mut_from_ref)]
-#[allow(clippy::clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 pub(crate) mod raw;
 
 /// HTTP errors
@@ -240,7 +240,7 @@ pub fn string_to_header_map(s: &str) -> Result<HeaderMap, Error> {
     let mut headers = HeaderMap::new();
     for entry in s.lines() {
         let mut parts = entry.splitn(2, ':');
-        #[allow(clippy::clippy::clippy::or_fun_call)]
+        #[allow(clippy::or_fun_call)]
         let k = parts.next().ok_or(anyhow::format_err!(
             "Invalid serialized header: [{}]",
             entry

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -147,7 +147,7 @@ mod tests {
 
         // Link `wasi_experimental_http`
         let http = HttpCtx::new(allowed_domains, max_concurrent_requests)?;
-        http.add_to_linker(&mut linker)?;
+        http.add_to_generic_linker(&mut linker)?;
 
         let module = wasmtime::Module::from_file(store.engine(), filename)?;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -147,7 +147,7 @@ mod tests {
 
         // Link `wasi_experimental_http`
         let http = HttpCtx::new(allowed_domains, max_concurrent_requests)?;
-        http.add_to_generic_linker(&mut linker)?;
+        http.add_to_linker(&mut linker)?;
 
         let module = wasmtime::Module::from_file(store.engine(), filename)?;
 

--- a/tests/rust/Cargo.toml
+++ b/tests/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "simple-wasi-http-tests"
+name    = "simple-wasi-http-tests"
 version = "0.1.0"
 authors = ["Radu Matei <radu.matei@microsoft.com>"]
 edition = "2018"
@@ -8,6 +8,6 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-bytes = "1"
-http = "0.2"
+bytes                  = "1"
+http                   = "0.2"
 wasi-experimental-http = { path = "../../crates/wasi-experimental-http" }


### PR DESCRIPTION
This commit updates Wasmtime to v0.30 due to a security advisory - see https://rustsec.org/advisories/RUSTSEC-2021-0110.html.

It also adds a utility function that makes it easy to use the library with a generic linker -- the previous `add_to_linker` implementation was unusable for any runtime that had a different kind of internal state.
This commit adds a generic function that accepts a `Linker<T>`.