### PR TITLE
Bump versions to v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "wasi-experimental-http-wasmtime-sample"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Radu Matei <radu.matei@microsoft.com>"]
 edition = "2018"
 

--- a/crates/as/package.json
+++ b/crates/as/package.json
@@ -3,7 +3,7 @@
   "main": "index.ts",
   "ascMain": "index.ts",
   "types": "index.ts",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Experimental HTTP library for AssemblyScript",
   "author": {
     "name": "The DeisLabs team at Microsoft"

--- a/crates/wasi-experimental-http-wasmtime/Cargo.toml
+++ b/crates/wasi-experimental-http-wasmtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "wasi-experimental-http-wasmtime"
-version     = "0.5.0"
+version     = "0.6.0"
 authors     = ["Radu Matei <radu.matei@microsoft.com>"]
 edition     = "2018"
 repository  = "https://github.com/deislabs/wasi-experimental-http"

--- a/crates/wasi-experimental-http/Cargo.toml
+++ b/crates/wasi-experimental-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "wasi-experimental-http"
-version     = "0.5.0"
+version     = "0.6.0"
 authors     = ["Radu Matei <radu.matei@microsoft.com>"]
 edition     = "2018"
 repository  = "https://github.com/deislabs/wasi-experimental-http"


### PR DESCRIPTION
See published packages:

- https://www.npmjs.com/package/@deislabs/wasi-experimental-http/v/0.6.0
- https://crates.io/crates/wasi-experimental-http/0.6.0
- https://crates.io/crates/wasi-experimental-http-wasmtime/0.6.0