### PR TITLE
Update Wasmtime to v0.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,26 +1,28 @@
 [package]
-name    = "wasi-experimental-http-wasmtime-sample"
-version = "0.6.0"
-authors = ["Radu Matei <radu.matei@microsoft.com>"]
-edition = "2018"
+    name    = "wasi-experimental-http-wasmtime-sample"
+    version = "0.6.0"
+    authors = ["Radu Matei <radu.matei@microsoft.com>"]
+    edition = "2021"
+
 
 [dependencies]
-anyhow                          = "1.0"
-futures                         = "0.3"
-http                            = "0.2"
-reqwest                         = { version = "0.11", default-features = true, features = ["json", "blocking"] }
-structopt                       = "0.3.21"
-tokio                           = { version = "1.4.0", features = ["full"] }
-wasmtime                        = "0.30.0"
-wasmtime-wasi                   = "0.30.0"
-wasi-common                     = "0.30.0"
-wasi-cap-std-sync               = "0.30.0"
-wasi-experimental-http          = { path = "crates/wasi-experimental-http" }
-wasi-experimental-http-wasmtime = { path = "crates/wasi-experimental-http-wasmtime" }
+    anyhow                          = "1.0"
+    futures                         = "0.3"
+    http                            = "0.2"
+    reqwest                         = { version = "0.11", default-features = true, features = ["json", "blocking"] }
+    structopt                       = "0.3"
+    tokio                           = { version = "1.4", features = ["full"] }
+    wasmtime                        = "0.31"
+    wasmtime-wasi                   = "0.31"
+    wasi-common                     = "0.31"
+    wasi-cap-std-sync               = "0.31"
+    wasi-experimental-http          = { path = "crates/wasi-experimental-http" }
+    wasi-experimental-http-wasmtime = { path = "crates/wasi-experimental-http-wasmtime" }
+
 
 [workspace]
-members = ["crates/wasi-experimental-http", "crates/wasi-experimental-http-wasmtime", "tests/rust"]
+    members = ["crates/wasi-experimental-http", "crates/wasi-experimental-http-wasmtime", "tests/rust"]
 
 [[bin]]
-name = "wasmtime-http"
-path = "bin/wasmtime-http.rs"
+    name = "wasmtime-http"
+    path = "bin/wasmtime-http.rs"

--- a/bin/wasmtime-http.rs
+++ b/bin/wasmtime-http.rs
@@ -114,8 +114,9 @@ fn invoke_func(func: Func, args: Vec<String>, mut store: impl AsContextMut) -> R
         });
     }
 
-    let results = func.call(&mut store, &values)?;
-    for result in results.into_vec() {
+    let mut results = vec![];
+    func.call(&mut store, &values, &mut results)?;
+    for result in results {
         match result {
             Val::I32(i) => println!("{}", i),
             Val::I64(i) => println!("{}", i),

--- a/crates/wasi-experimental-http-wasmtime/Cargo.toml
+++ b/crates/wasi-experimental-http-wasmtime/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name        = "wasi-experimental-http-wasmtime"
-version     = "0.6.0"
-authors     = ["Radu Matei <radu.matei@microsoft.com>"]
-edition     = "2018"
-repository  = "https://github.com/deislabs/wasi-experimental-http"
-license     = "MIT"
-description = "Experimental HTTP library for WebAssembly in Wasmtime"
-readme      = "readme.md"
+    name        = "wasi-experimental-http-wasmtime"
+    version     = "0.6.0"
+    authors     = ["Radu Matei <radu.matei@microsoft.com>"]
+    edition     = "2021"
+    repository  = "https://github.com/deislabs/wasi-experimental-http"
+    license     = "MIT"
+    description = "Experimental HTTP library for WebAssembly in Wasmtime"
+    readme      = "readme.md"
 
 [dependencies]
-anyhow        = "1.0"
-bytes         = "1"
-futures       = "0.3"
-http          = "0.2"
-reqwest       = { version = "0.11", default-features = true, features = ["json", "blocking"] }
-thiserror     = "1.0"
-tokio         = { version = "1.4.0", features = ["full"] }
-tracing       = { version = "0.1", features = ["log"] }
-url           = "2.2.1"
-wasmtime      = "0.30"
-wasmtime-wasi = "0.30"
-wasi-common   = "0.30"
+    anyhow        = "1.0"
+    bytes         = "1"
+    futures       = "0.3"
+    http          = "0.2"
+    reqwest       = { version = "0.11", default-features = true, features = ["json", "blocking"] }
+    thiserror     = "1.0"
+    tokio         = { version = "1.4.0", features = ["full"] }
+    tracing       = { version = "0.1", features = ["log"] }
+    url           = "2.2.1"
+    wasmtime      = "0.31"
+    wasmtime-wasi = "0.31"
+    wasi-common   = "0.31"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -88,7 +88,7 @@ mod tests {
             .get_func(&mut store, func)
             .unwrap_or_else(|| panic!("cannot find function {}", func));
 
-        func.call(&mut store, &[]).unwrap();
+        func.call(&mut store, &[], &mut vec![]).unwrap();
     }
 
     fn setup_tests(allowed_domains: Option<Vec<String>>, max_concurrent_requests: Option<u32>) {
@@ -119,7 +119,7 @@ mod tests {
             let func = instance
                 .get_func(&mut store, func_name)
                 .unwrap_or_else(|| panic!("cannot find function {}", func_name));
-            func.call(&mut store, &[])?;
+            func.call(&mut store, &[], &mut vec![])?;
         }
 
         Ok(())


### PR DESCRIPTION
This PR updates Wasmtime to the latest version, v0.31.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>