### PR TITLE
chore: update package versions to v0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,27 +1,32 @@
 [package]
     name    = "wasi-experimental-http-wasmtime-sample"
-    version = "0.6.0"
-    authors = ["Radu Matei <radu.matei@microsoft.com>"]
+    version = "0.7.0"
+    authors = [ "Radu Matei <radu.matei@microsoft.com>" ]
     edition = "2021"
 
-
 [dependencies]
-    anyhow                          = "1.0"
-    futures                         = "0.3"
-    http                            = "0.2"
-    reqwest                         = { version = "0.11", default-features = true, features = ["json", "blocking"] }
-    structopt                       = "0.3"
-    tokio                           = { version = "1.4", features = ["full"] }
-    wasmtime                        = "0.31"
-    wasmtime-wasi                   = "0.31"
-    wasi-common                     = "0.31"
-    wasi-cap-std-sync               = "0.31"
-    wasi-experimental-http          = { path = "crates/wasi-experimental-http" }
+    anyhow = "1.0"
+    futures = "0.3"
+    http = "0.2"
+    reqwest = { version = "0.11", default-features = true, features = [
+        "json",
+        "blocking",
+    ] }
+    structopt = "0.3"
+    tokio = { version = "1.4", features = [ "full" ] }
+    wasmtime = "0.31"
+    wasmtime-wasi = "0.31"
+    wasi-common = "0.31"
+    wasi-cap-std-sync = "0.31"
+    wasi-experimental-http = { path = "crates/wasi-experimental-http" }
     wasi-experimental-http-wasmtime = { path = "crates/wasi-experimental-http-wasmtime" }
 
-
 [workspace]
-    members = ["crates/wasi-experimental-http", "crates/wasi-experimental-http-wasmtime", "tests/rust"]
+    members = [
+        "crates/wasi-experimental-http",
+        "crates/wasi-experimental-http-wasmtime",
+        "tests/rust",
+    ]
 
 [[bin]]
     name = "wasmtime-http"

--- a/crates/as/package.json
+++ b/crates/as/package.json
@@ -3,7 +3,7 @@
   "main": "index.ts",
   "ascMain": "index.ts",
   "types": "index.ts",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Experimental HTTP library for AssemblyScript",
   "author": {
     "name": "The DeisLabs team at Microsoft"

--- a/crates/wasi-experimental-http-wasmtime/Cargo.toml
+++ b/crates/wasi-experimental-http-wasmtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
     name        = "wasi-experimental-http-wasmtime"
-    version     = "0.6.0"
-    authors     = ["Radu Matei <radu.matei@microsoft.com>"]
+    version     = "0.7.0"
+    authors     = [ "Radu Matei <radu.matei@microsoft.com>" ]
     edition     = "2021"
     repository  = "https://github.com/deislabs/wasi-experimental-http"
     license     = "MIT"
@@ -9,15 +9,18 @@
     readme      = "readme.md"
 
 [dependencies]
-    anyhow        = "1.0"
-    bytes         = "1"
-    futures       = "0.3"
-    http          = "0.2"
-    reqwest       = { version = "0.11", default-features = true, features = ["json", "blocking"] }
-    thiserror     = "1.0"
-    tokio         = { version = "1.4.0", features = ["full"] }
-    tracing       = { version = "0.1", features = ["log"] }
-    url           = "2.2.1"
-    wasmtime      = "0.31"
+    anyhow = "1.0"
+    bytes = "1"
+    futures = "0.3"
+    http = "0.2"
+    reqwest = { version = "0.11", default-features = true, features = [
+        "json",
+        "blocking",
+    ] }
+    thiserror = "1.0"
+    tokio = { version = "1.4.0", features = [ "full" ] }
+    tracing = { version = "0.1", features = [ "log" ] }
+    url = "2.2.1"
+    wasmtime = "0.31"
     wasmtime-wasi = "0.31"
-    wasi-common   = "0.31"
+    wasi-common = "0.31"

--- a/crates/wasi-experimental-http/Cargo.toml
+++ b/crates/wasi-experimental-http/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name        = "wasi-experimental-http"
-version     = "0.6.0"
-authors     = ["Radu Matei <radu.matei@microsoft.com>"]
-edition     = "2018"
-repository  = "https://github.com/deislabs/wasi-experimental-http"
-license     = "MIT"
-description = "Experimental HTTP library for WebAssembly"
-readme      = "readme.md"
+    name        = "wasi-experimental-http"
+    version     = "0.7.0"
+    authors     = [ "Radu Matei <radu.matei@microsoft.com>" ]
+    edition     = "2018"
+    repository  = "https://github.com/deislabs/wasi-experimental-http"
+    license     = "MIT"
+    description = "Experimental HTTP library for WebAssembly"
+    readme      = "readme.md"
 
 [dependencies]
-anyhow    = "1.0"
-bytes     = "1"
-http      = "0.2"
-thiserror = "1.0"
-tracing   = { version = "0.1", features = ["log"] }
+    anyhow    = "1.0"
+    bytes     = "1"
+    http      = "0.2"
+    thiserror = "1.0"
+    tracing   = { version = "0.1", features = [ "log" ] }


### PR DESCRIPTION
See published packages:

- https://www.npmjs.com/package/@deislabs/wasi-experimental-http/v/0.7.0
- https://crates.io/crates/wasi-experimental-http/0.7.0
- https://crates.io/crates/wasi-experimental-http-wasmtime/0.7.0

Signed-off-by: Radu Matei <radu.matei@fermyon.com>