### PR TITLE
chore: update Wasmtime to v0.33 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@
     ] }
     structopt = "0.3"
     tokio = { version = "1.4", features = [ "full" ] }
-    wasmtime = "0.31"
-    wasmtime-wasi = "0.31"
-    wasi-common = "0.31"
-    wasi-cap-std-sync = "0.31"
+    wasmtime = "0.33"
+    wasmtime-wasi = "0.33"
+    wasi-common = "0.33"
+    wasi-cap-std-sync = "0.33"
     wasi-experimental-http = { path = "crates/wasi-experimental-http" }
     wasi-experimental-http-wasmtime = { path = "crates/wasi-experimental-http-wasmtime" }
 

--- a/crates/wasi-experimental-http-wasmtime/Cargo.toml
+++ b/crates/wasi-experimental-http-wasmtime/Cargo.toml
@@ -21,6 +21,6 @@
     tokio = { version = "1.4.0", features = [ "full" ] }
     tracing = { version = "0.1", features = [ "log" ] }
     url = "2.2.1"
-    wasmtime = "0.31"
-    wasmtime-wasi = "0.31"
-    wasi-common = "0.31"
+    wasmtime = "0.33"
+    wasmtime-wasi = "0.33"
+    wasi-common = "0.33"


### PR DESCRIPTION
depends on #80 

This commit updates Wasmtime to v0.33.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>