### PR TITLE
WIP: add request config

### DIFF
--- a/crates/as/raw.ts
+++ b/crates/as/raw.ts
@@ -120,6 +120,8 @@ export declare function req(
     headers_len: usize,
     body_ptr: WasiPtr<u8>,
     body_len: usize,
+    config_ptr: WasiPtr<u8>,
+    config_len: usize,
     result_0_ptr: WasiMutPtr<StatusCode>,
     result_1_ptr: WasiMutPtr<ResponseHandle>
 ): HttpError;

--- a/crates/wasi-experimental-http-wasmtime/Cargo.toml
+++ b/crates/wasi-experimental-http-wasmtime/Cargo.toml
@@ -8,8 +8,14 @@
     description = "Experimental HTTP library for WebAssembly in Wasmtime"
     readme      = "readme.md"
 
+[features]
+    default = [ "native-tls" ]
+    native-tls = [ "openssl", "reqwest/native-tls" ]
+    rustls-tls = [ "reqwest/rustls-tls" ]
+
 [dependencies]
     anyhow = "1.0"
+    cfg-if = "1.0.0"
     bytes = "1"
     futures = "0.3"
     http = "0.2"
@@ -17,6 +23,9 @@
         "json",
         "blocking",
     ] }
+    openssl = { version = "0.10.38", optional = true }
+    rmp-serde = "0.15.5"
+    serde = { version = "1.0.132", features = [ "derive" ] }
     thiserror = "1.0"
     tokio = { version = "1.4.0", features = [ "full" ] }
     tracing = { version = "0.1", features = [ "log" ] }
@@ -24,3 +33,4 @@
     wasmtime = "0.31"
     wasmtime-wasi = "0.31"
     wasi-common = "0.31"
+    wasi-experimental-http = { path = "../wasi-experimental-http" }

--- a/crates/wasi-experimental-http/Cargo.toml
+++ b/crates/wasi-experimental-http/Cargo.toml
@@ -12,5 +12,7 @@
     anyhow    = "1.0"
     bytes     = "1"
     http      = "0.2"
+    rmp-serde = "0.15.5"
+    serde     = { version = "1.0.132", features = [ "derive" ] }
     thiserror = "1.0"
     tracing   = { version = "0.1", features = [ "log" ] }

--- a/crates/wasi-experimental-http/src/raw.rs
+++ b/crates/wasi-experimental-http/src/raw.rs
@@ -159,6 +159,8 @@ pub fn req(
     headers_len: usize,
     body_ptr: WasiPtr<u8>,
     body_len: usize,
+    config_ptr: WasiPtr<u8>,
+    config_len: usize,
 ) -> Result<(StatusCode, ResponseHandle), Error> {
     #[link(wasm_import_module = "wasi_experimental_http")]
     extern "C" {
@@ -171,6 +173,8 @@ pub fn req(
             headers_len: usize,
             body_ptr: WasiPtr<u8>,
             body_len: usize,
+            config_ptr: WasiPtr<u8>,
+            config_len: usize,
             result_0_ptr: WasiMutPtr<StatusCode>,
             result_1_ptr: WasiMutPtr<ResponseHandle>,
         ) -> HttpError;
@@ -186,6 +190,8 @@ pub fn req(
         headers_len,
         body_ptr,
         body_len,
+        config_ptr,
+        config_len,
         result_0_ptr.as_mut_ptr(),
         result_1_ptr.as_mut_ptr(),
     )};

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -94,7 +94,8 @@ mod tests {
     fn setup_tests(allowed_domains: Option<Vec<String>>, max_concurrent_requests: Option<u32>) {
         let modules = vec![
             "target/wasm32-wasi/release/simple_wasi_http_tests.wasm",
-            "tests/as/build/optimized.wasm",
+            //TODO: fix broken test by implementing assemblyscript glue code
+            //"tests/as/build/optimized.wasm",
         ];
         let test_funcs = vec!["get", "post"];
 

--- a/tests/rust/src/lib.rs
+++ b/tests/rust/src/lib.rs
@@ -4,7 +4,9 @@ use bytes::Bytes;
 pub extern "C" fn get() {
     let url = "https://api.brigade.sh/healthz".to_string();
     let req = http::request::Builder::new().uri(&url).body(None).unwrap();
-    let mut res = wasi_experimental_http::request(req).expect("cannot make get request");
+    let req_cfg = wasi_experimental_http::RequestConfig::default();
+    let mut res =
+        wasi_experimental_http::request(req, Some(req_cfg)).expect("cannot make get request");
     let str = std::str::from_utf8(&res.body_read_all().unwrap())
         .unwrap()
         .to_string();
@@ -30,7 +32,7 @@ pub extern "C" fn post() {
     let b = Bytes::from("Testing with a request body. Does this actually work?");
     let req = req.body(Some(b)).unwrap();
 
-    let mut res = wasi_experimental_http::request(req).expect("cannot make post request");
+    let mut res = wasi_experimental_http::request(req, None).expect("cannot make post request");
     let _ = std::str::from_utf8(&res.body_read_all().unwrap())
         .unwrap()
         .to_string();
@@ -56,5 +58,5 @@ pub extern "C" fn concurrent() {
 
 fn make_req(url: String) -> wasi_experimental_http::Response {
     let req = http::request::Builder::new().uri(&url).body(None).unwrap();
-    wasi_experimental_http::request(req).expect("cannot make get request")
+    wasi_experimental_http::request(req, None).expect("cannot make get request")
 }

--- a/witx/readme.md
+++ b/witx/readme.md
@@ -99,6 +99,7 @@ Returned error type: _[`http_error`](#http_error)_
 * **`method`**: `string`
 * **`headers`**: `string`
 * **`body`**: _[`outgoing_body`](#outgoing_body)_
+* **`config`**: `u8` slice
 
 #### Output:
 

--- a/witx/wasi_experimental_http.witx
+++ b/witx/wasi_experimental_http.witx
@@ -60,6 +60,7 @@
         (param $method string)
         (param $headers string)
         (param $body $outgoing_body)
+        (param $config (in-buffer u8))
         (result $error (expected (tuple $status_code $response_handle) (error $http_error)))
     )
 


### PR DESCRIPTION
This PR extends the `req` API to take a second, optional parameter. This parameter contains some tuning values such as:

  * The list of extra CAs to be trusted. This is useful when interacting with servers that use self-signed certificates
  * The client certificate and key. This is useful when the remote server requires mutual TLS authentication.
  * And more things... :)

These settings are stored into a dedicates Struct which is modeled after what reqwest uses. The struct is controller by the Wasm client (this makes it possible to have a client specify its own identity, instead of having all the outgoing request from the host to use the same identity).
The request configuration is serialized to MsgPack by the Wasm guest, and is then deserialized by the Wasm host.

Currently only the Rust guest code has been extended to handle this serialization. The AssemblyScript code needs to be written. I can do that, but I would like to gather your feedback before doing that.

BTW, I picked MsgPack because we can reuse the [waPC libraries](https://github.com/wapc) made available for different programming languages to serialize structures into MsgPack.

## Why did I do that?

During the holidays I played a bit with Wagi. I tried to interact with the Kubernetes API from within a Wasm module. To do that I used this crate to perform my requests.

As you probably know, the Kubernetes API server is exposed over a TLS endpoint that is often secured by a self-signed certificate. 
Moreover, the client authentication can work in two ways: either through a token sent inside of the request headers or via client certificates. Obviously I wanted to use the client certificates, which was not doable before this PR.

The final outcome, which deserves a blog post on its own, works pretty well. I implemented a webhook endpoint using Wagi + Rust modules using this crate that can trigger actions inside of a Kubernetes cluster :sunglasses: 

I had to make some small changes to Wagi too, I'll create a PR once I know if you're interested in this feature :)
