### PR TITLE
chore: update Wasmtime to v0.34 and bump packages to v0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
     name    = "wasi-experimental-http-wasmtime-sample"
-    version = "0.8.0"
+    version = "0.9.0"
     authors = [ "Radu Matei <radu.matei@microsoft.com>" ]
     edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@
     ] }
     structopt = "0.3"
     tokio = { version = "1.4", features = [ "full" ] }
-    wasmtime = "0.33"
-    wasmtime-wasi = "0.33"
-    wasi-common = "0.33"
-    wasi-cap-std-sync = "0.33"
+    wasmtime = "0.34"
+    wasmtime-wasi = "0.34"
+    wasi-common = "0.34"
+    wasi-cap-std-sync = "0.34"
     wasi-experimental-http = { path = "crates/wasi-experimental-http" }
     wasi-experimental-http-wasmtime = { path = "crates/wasi-experimental-http-wasmtime" }
 

--- a/crates/as/package.json
+++ b/crates/as/package.json
@@ -3,7 +3,7 @@
   "main": "index.ts",
   "ascMain": "index.ts",
   "types": "index.ts",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Experimental HTTP library for AssemblyScript",
   "author": {
     "name": "The DeisLabs team at Microsoft"

--- a/crates/wasi-experimental-http-wasmtime/Cargo.toml
+++ b/crates/wasi-experimental-http-wasmtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
     name        = "wasi-experimental-http-wasmtime"
-    version     = "0.8.0"
+    version     = "0.9.0"
     authors     = [ "Radu Matei <radu.matei@microsoft.com>" ]
     edition     = "2021"
     repository  = "https://github.com/deislabs/wasi-experimental-http"

--- a/crates/wasi-experimental-http-wasmtime/Cargo.toml
+++ b/crates/wasi-experimental-http-wasmtime/Cargo.toml
@@ -21,6 +21,6 @@
     tokio = { version = "1.4.0", features = [ "full" ] }
     tracing = { version = "0.1", features = [ "log" ] }
     url = "2.2.1"
-    wasmtime = "0.33"
-    wasmtime-wasi = "0.33"
-    wasi-common = "0.33"
+    wasmtime = "0.34"
+    wasmtime-wasi = "0.34"
+    wasi-common = "0.34"

--- a/crates/wasi-experimental-http/Cargo.toml
+++ b/crates/wasi-experimental-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
     name        = "wasi-experimental-http"
-    version     = "0.8.0"
+    version     = "0.9.0"
     authors     = [ "Radu Matei <radu.matei@microsoft.com>" ]
     edition     = "2018"
     repository  = "https://github.com/deislabs/wasi-experimental-http"


### PR DESCRIPTION
See packages:

- https://crates.io/crates/wasi-experimental-http/0.9.0
- https://crates.io/crates/wasi-experimental-http-wasmtime/0.9.0
- https://www.npmjs.com/package/@deislabs/wasi-experimental-http/v/0.9.0