### PR TITLE
chore: update Wasmtime to v0.35

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@
     ] }
     structopt = "0.3"
     tokio = { version = "1.4", features = [ "full" ] }
-    wasmtime = "0.34"
-    wasmtime-wasi = "0.34"
-    wasi-common = "0.34"
-    wasi-cap-std-sync = "0.34"
+    wasmtime = "0.35"
+    wasmtime-wasi = "0.35"
+    wasi-common = "0.35"
+    wasi-cap-std-sync = "0.35"
     wasi-experimental-http = { path = "crates/wasi-experimental-http" }
     wasi-experimental-http-wasmtime = { path = "crates/wasi-experimental-http-wasmtime" }
 

--- a/crates/wasi-experimental-http-wasmtime/Cargo.toml
+++ b/crates/wasi-experimental-http-wasmtime/Cargo.toml
@@ -21,6 +21,6 @@
     tokio = { version = "1.4.0", features = [ "full" ] }
     tracing = { version = "0.1", features = [ "log" ] }
     url = "2.2.1"
-    wasmtime = "0.34"
-    wasmtime-wasi = "0.34"
-    wasi-common = "0.34"
+    wasmtime = "0.35"
+    wasmtime-wasi = "0.35"
+    wasi-common = "0.35"


### PR DESCRIPTION
This commit updates Wasmtime to v0.35

Signed-off-by: Radu Matei <radu.matei@fermyon.com>