### PR TITLE
Check `origin` instead of `host`

### DIFF
--- a/crates/wasi-experimental-http-wasmtime/src/lib.rs
+++ b/crates/wasi-experimental-http-wasmtime/src/lib.rs
@@ -615,7 +615,7 @@ fn string_from_memory(
 fn is_allowed(url: &str, allowed_hosts: Option<&[String]>) -> Result<bool, HttpError> {
     let url_host = Url::parse(url)
         .map_err(|_| HttpError::InvalidUrl)?
-        .host_str()
+        .origin()
         .ok_or(HttpError::InvalidUrl)?
         .to_owned();
     match allowed_hosts {


### PR DESCRIPTION
Fix for issue: https://github.com/deislabs/wasi-experimental-http/issues/87