### PR TITLE
refactor!: change type of `HttpState::add_to_linker`'s `get_cx` parameter

### DIFF
--- a/bin/wasmtime-http.rs
+++ b/bin/wasmtime-http.rs
@@ -108,7 +108,9 @@ fn create_instance(
     })?;
     // Link `wasi_experimental_http`
     let http = HttpState::new()?;
-    http.add_to_linker(&mut linker, |cx: &WasmtimeHttpCtx| -> &HttpCtx { &cx.http })?;
+    http.add_to_linker(&mut linker, |cx: &WasmtimeHttpCtx| -> HttpCtx {
+        cx.http.clone()
+    })?;
 
     let module = wasmtime::Module::from_file(store.engine(), filename)?;
     let instance = linker.instantiate(&mut store, &module)?;

--- a/crates/wasi-experimental-http-wasmtime/Cargo.toml
+++ b/crates/wasi-experimental-http-wasmtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
     name        = "wasi-experimental-http-wasmtime"
-    version     = "0.9.0"
+    version     = "0.10.0"
     authors     = [ "Radu Matei <radu.matei@microsoft.com>" ]
     edition     = "2021"
     repository  = "https://github.com/deislabs/wasi-experimental-http"

--- a/crates/wasi-experimental-http-wasmtime/src/lib.rs
+++ b/crates/wasi-experimental-http-wasmtime/src/lib.rs
@@ -321,6 +321,7 @@ impl HostCalls {
 
 /// Per-instance context data used to control whether the guest
 /// is allowed to make an outbound HTTP request.
+#[derive(Clone)]
 pub struct HttpCtx {
     pub allowed_hosts: Option<Vec<String>>,
     pub max_concurrent_requests: Option<u32>,
@@ -346,7 +347,7 @@ impl HttpState {
     pub fn add_to_linker<T>(
         &self,
         linker: &mut Linker<T>,
-        get_cx: impl Fn(&T) -> &HttpCtx + Send + Sync + Copy + 'static,
+        get_cx: impl Fn(&T) -> HttpCtx + Send + Sync + 'static,
     ) -> Result<(), Error> {
         let st = self.state.clone();
         linker.func_wrap(
@@ -486,7 +487,7 @@ impl HttpState {
 
                 match HostCalls::req(
                     st.clone(),
-                    http_ctx.allowed_hosts.clone().as_deref(),
+                    http_ctx.allowed_hosts.as_deref(),
                     http_ctx.max_concurrent_requests,
                     memory,
                     ctx,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -169,8 +169,8 @@ mod tests {
 
         // Link `wasi_experimental_http`
         let http = HttpState::new()?;
-        http.add_to_linker(&mut linker, |cx: &IntegrationTestsCtx| -> &HttpCtx {
-            &cx.http
+        http.add_to_linker(&mut linker, |cx: &IntegrationTestsCtx| -> HttpCtx {
+            cx.http.clone()
         })?;
 
         let module = wasmtime::Module::from_file(store.engine(), filename)?;


### PR DESCRIPTION
BREAKING CHANGE: The type of this parameter has changed from `impl Fn(&T) ->
&HttpCtx + Send + Sync + Copy + 'static` to `impl Fn(&T) -> HttpCtx + Send +
Sync + 'static`.  Besides removing the `Copy` bound (which wasn't needed), I've
changed the return type from `&HttpCtx` to `HttpCtx`.

The rationale for this is that the return value of `get_cx` was effectively
being cloned anyway immediately after calling it, so there was no efficiency
gain from returning a reference.  Also, any implementation of the original type
would have to ensure the returned reference has the same lifetime as the context
parameter, which essentially means the implementation is forced to store the
`HttpCtx` inside the context.  That's overkill for e.g. `wagi`, which has no
need for per-context HTTP configuration.

Signed-off-by: Joel Dice <joel.dice@gmail.com>