### PR TITLE
chore: update package versions to v0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
     name    = "wasi-experimental-http-wasmtime-sample"
-    version = "0.9.0"
+    version = "0.10.0"
     authors = [ "Radu Matei <radu.matei@microsoft.com>" ]
     edition = "2021"
 

--- a/crates/as/package.json
+++ b/crates/as/package.json
@@ -3,7 +3,7 @@
   "main": "index.ts",
   "ascMain": "index.ts",
   "types": "index.ts",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Experimental HTTP library for AssemblyScript",
   "author": {
     "name": "The DeisLabs team at Microsoft"

--- a/crates/wasi-experimental-http/Cargo.toml
+++ b/crates/wasi-experimental-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
     name        = "wasi-experimental-http"
-    version     = "0.9.0"
+    version     = "0.10.0"
     authors     = [ "Radu Matei <radu.matei@microsoft.com>" ]
     edition     = "2018"
     repository  = "https://github.com/deislabs/wasi-experimental-http"


### PR DESCRIPTION
See published packages:

- https://crates.io/crates/wasi-experimental-http/0.10.0
- https://crates.io/crates/wasi-experimental-http-wasmtime/0.10.0
- https://www.npmjs.com/package/@deislabs/wasi-experimental-http/v/0.10.0


Signed-off-by: Radu Matei <radu.matei@fermyon.com>