### PR TITLE
chore: update assemblyscript deps

### DIFF
--- a/crates/as/index.ts
+++ b/crates/as/index.ts
@@ -1,6 +1,6 @@
 // required to use --abort=as-wasi
 // @ts-ignore
-import { Console } from "as-wasi";
+import { Console } from "as-wasi/assembly";
 import * as raw from "./raw";
 
 /** Send an HTTP request and return an HTTP response.

--- a/crates/as/package.json
+++ b/crates/as/package.json
@@ -21,7 +21,7 @@
     "asbuild": "asc index.ts -b build/optimized.wasm --use abort=wasi_abort --debug"
   },
   "dependencies": {
-    "as-wasi": "0.4.4",
-    "assemblyscript": "^0.18.16"
+    "as-wasi": "^0.4.6",
+    "assemblyscript": "^0.20.18"
   }
 }


### PR DESCRIPTION
Updates assemblyscript and as-wasi to the latest versions.

Updates index.ts to import from as-wasi/assembly, according to [this comment from the as-wasi repo](https://github.com/AssemblyScript/assemblyscript/issues/2259#issuecomment-1094930774)

Closes #92