### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@
     ] }
     structopt = "0.3"
     tokio = { version = "1.4", features = [ "full" ] }
-    wasmtime = "0.35"
-    wasmtime-wasi = "0.35"
-    wasi-common = "0.35"
-    wasi-cap-std-sync = "0.35"
+    wasmtime = "5.0.0"
+    wasmtime-wasi = "5.0.1"
+    wasi-common = "5.0.1"
+    wasi-cap-std-sync = "5.0.1"
     wasi-experimental-http = { path = "crates/wasi-experimental-http" }
     wasi-experimental-http-wasmtime = { path = "crates/wasi-experimental-http-wasmtime" }
 

--- a/bin/wasmtime-http.rs
+++ b/bin/wasmtime-http.rs
@@ -81,7 +81,6 @@ fn create_instance(
 ) -> Result<(Instance, Store<WasmtimeHttpCtx>), Error> {
     let mut wasmtime_config = wasmtime::Config::default();
     wasmtime_config.wasm_multi_memory(true);
-    wasmtime_config.wasm_module_linking(true);
     let engine = Engine::new(&wasmtime_config)?;
     let mut linker = Linker::new(&engine);
 

--- a/crates/wasi-experimental-http-wasmtime/Cargo.toml
+++ b/crates/wasi-experimental-http-wasmtime/Cargo.toml
@@ -21,6 +21,6 @@
     tokio = { version = "1.4.0", features = [ "full" ] }
     tracing = { version = "0.1", features = [ "log" ] }
     url = "2.2.1"
-    wasmtime = "0.35"
-    wasmtime-wasi = "0.35"
-    wasi-common = "0.35"
+    wasmtime = "5.0.1"
+    wasmtime-wasi = "5.0.1"
+    wasi-common = "5.0.1"


### PR DESCRIPTION
This updates the various wasmtime dependencies to their current (as of March 14 2023) versions, and removes a call to enable module linking in wasmtime as that feature was [removed last year](https://github.com/bytecodealliance/wasmtime/commit/76b82910c99fba36fa75efb0a90b92379853f329).